### PR TITLE
fix(WEB-1047): add Office Services database migration

### DIFF
--- a/src/main/java/org/apache/fineract/office/service/OfficeExtensionWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/office/service/OfficeExtensionWritePlatformServiceImpl.java
@@ -61,6 +61,7 @@ public class OfficeExtensionWritePlatformServiceImpl
 
     final JsonElement element = this.fromJsonHelper.parse(jsonBody);
     final String serviceName = this.fromJsonHelper.extractStringNamed("serviceName", element);
+    validateServiceName(serviceName);
     final String serviceExternalId =
         this.fromJsonHelper.extractStringNamed("serviceExternalId", element);
     final String workingHours = this.fromJsonHelper.extractStringNamed("workingHours", element);
@@ -103,6 +104,7 @@ public class OfficeExtensionWritePlatformServiceImpl
 
     if (this.fromJsonHelper.parameterExists("serviceName", element)) {
       final String serviceName = this.fromJsonHelper.extractStringNamed("serviceName", element);
+      validateServiceName(serviceName);
       sql.append("service_name = :serviceName");
       params.addValue("serviceName", serviceName);
       changes.put("serviceName", serviceName);
@@ -223,6 +225,17 @@ public class OfficeExtensionWritePlatformServiceImpl
           "SELECT 1 FROM m_office WHERE id = ?", Integer.class, officeId);
     } catch (final EmptyResultDataAccessException e) {
       throw new OfficeNotFoundException(officeId, e);
+    }
+  }
+
+  private void validateServiceName(final String serviceName) {
+    final List<ApiParameterError> errors = new ArrayList<>();
+    final DataValidatorBuilder validator = new DataValidatorBuilder(errors).resource(RESOURCE_NAME);
+
+    validator.parameter("serviceName").value(serviceName).notBlank().notExceedingLengthOf(255);
+
+    if (!errors.isEmpty()) {
+      throw new PlatformApiDataValidationException(errors);
     }
   }
 

--- a/src/main/resources/db/changelog/tenant/module/savings/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/savings/module-changelog-master.xml
@@ -54,4 +54,5 @@
   <include file="parts/042-add-bccr-service-configuration.xml" relativeToChangelogFile="true"/>
   <include file="parts/043-add-bccr-permissions.xml" relativeToChangelogFile="true"/>
   <include file="parts/044-create-initial-sinpe-audit-schema.xml" relativeToChangelogFile="true"/>  
+  <include file="parts/045-create-office-services-table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/savings/parts/045-create-office-services-table.xml
+++ b/src/main/resources/db/changelog/tenant/module/savings/parts/045-create-office-services-table.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright since 2026 Mifos Initiative
+
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="savings-045-1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="m_selfservice_office_service"/>
+            </not>
+        </preConditions>
+
+        <comment>Create office services table</comment>
+
+        <createTable tableName="m_selfservice_office_service">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="office_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="service_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="service_external_id" type="VARCHAR(100)"/>
+            <column name="working_hours" type="VARCHAR(255)"/>
+        </createTable>
+
+        <addForeignKeyConstraint constraintName="fk_selfservice_office_service_office"
+                                 baseTableName="m_selfservice_office_service" baseColumnNames="office_id"
+                                 referencedTableName="m_office" referencedColumnNames="id"
+                                 onDelete="RESTRICT" onUpdate="RESTRICT"/>
+
+        <createIndex indexName="idx_selfservice_office_service_office" tableName="m_selfservice_office_service">
+            <column name="office_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/office/service/OfficeExtensionWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/office/service/OfficeExtensionWritePlatformServiceImplTest.java
@@ -100,6 +100,67 @@ class OfficeExtensionWritePlatformServiceImplTest {
   }
 
   @Test
+  void createOfficeService_nullServiceName_throws() {
+    mockAuth();
+    when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq(OFFICE_ID))).thenReturn(1);
+
+    String json = "{\"workingHours\":\"Mon-Fri\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.extractStringNamed("serviceName", element)).thenReturn(null);
+
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> service.createOfficeService(OFFICE_ID, json));
+    verify(namedJdbcTemplate, never())
+        .update(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            any(org.springframework.jdbc.support.GeneratedKeyHolder.class),
+            any(String[].class));
+  }
+
+  @Test
+  void createOfficeService_blankServiceName_throws() {
+    mockAuth();
+    when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq(OFFICE_ID))).thenReturn(1);
+
+    String json = "{\"serviceName\":\"   \",\"workingHours\":\"Mon-Fri\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.extractStringNamed("serviceName", element)).thenReturn("   ");
+
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> service.createOfficeService(OFFICE_ID, json));
+    verify(namedJdbcTemplate, never())
+        .update(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            any(org.springframework.jdbc.support.GeneratedKeyHolder.class),
+            any(String[].class));
+  }
+
+  @Test
+  void createOfficeService_serviceNameTooLong_throws() {
+    mockAuth();
+    when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq(OFFICE_ID))).thenReturn(1);
+
+    final String serviceName = "A".repeat(256);
+    String json = "{\"serviceName\":\"" + serviceName + "\",\"workingHours\":\"Mon-Fri\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.extractStringNamed("serviceName", element)).thenReturn(serviceName);
+
+    assertThrows(
+        PlatformApiDataValidationException.class, () -> service.createOfficeService(OFFICE_ID, json));
+    verify(namedJdbcTemplate, never())
+        .update(
+            anyString(),
+            any(MapSqlParameterSource.class),
+            any(org.springframework.jdbc.support.GeneratedKeyHolder.class),
+            any(String[].class));
+  }
+
+  @Test
   void updateOfficeService_withServiceName_updatesAndReturnsChanges() {
     mockAuth();
 
@@ -137,6 +198,79 @@ class OfficeExtensionWritePlatformServiceImplTest {
 
     assertNotNull(result);
     assertEquals(3, result.getChanges().size());
+  }
+
+  @Test
+  void updateOfficeService_withServiceExternalIdOnly_updatesAndReturnsChanges() {
+    mockAuth();
+
+    String json = "{\"serviceExternalId\":\"external-1\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.parameterExists("serviceName", element)).thenReturn(false);
+    when(fromJsonHelper.parameterExists("serviceExternalId", element)).thenReturn(true);
+    when(fromJsonHelper.extractStringNamed("serviceExternalId", element)).thenReturn("external-1");
+    when(fromJsonHelper.parameterExists("workingHours", element)).thenReturn(false);
+    when(namedJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class))).thenReturn(1);
+
+    CommandProcessingResult result = service.updateOfficeService(OFFICE_ID, SERVICE_ID, json);
+
+    assertNotNull(result);
+    assertEquals(1, result.getChanges().size());
+    assertEquals("external-1", result.getChanges().get("serviceExternalId"));
+  }
+
+  @Test
+  void updateOfficeService_withWorkingHoursOnly_updatesAndReturnsChanges() {
+    mockAuth();
+
+    String json = "{\"workingHours\":\"Mon-Fri\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.parameterExists("serviceName", element)).thenReturn(false);
+    when(fromJsonHelper.parameterExists("serviceExternalId", element)).thenReturn(false);
+    when(fromJsonHelper.parameterExists("workingHours", element)).thenReturn(true);
+    when(fromJsonHelper.extractStringNamed("workingHours", element)).thenReturn("Mon-Fri");
+    when(namedJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class))).thenReturn(1);
+
+    CommandProcessingResult result = service.updateOfficeService(OFFICE_ID, SERVICE_ID, json);
+
+    assertNotNull(result);
+    assertEquals(1, result.getChanges().size());
+    assertEquals("Mon-Fri", result.getChanges().get("workingHours"));
+  }
+
+  @Test
+  void updateOfficeService_blankServiceName_throws() {
+    mockAuth();
+
+    String json = "{\"serviceName\":\" \"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.parameterExists("serviceName", element)).thenReturn(true);
+    when(fromJsonHelper.extractStringNamed("serviceName", element)).thenReturn(" ");
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateOfficeService(OFFICE_ID, SERVICE_ID, json));
+    verify(namedJdbcTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+  @Test
+  void updateOfficeService_serviceNameTooLong_throws() {
+    mockAuth();
+
+    final String serviceName = "A".repeat(256);
+    String json = "{\"serviceName\":\"" + serviceName + "\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.parameterExists("serviceName", element)).thenReturn(true);
+    when(fromJsonHelper.extractStringNamed("serviceName", element)).thenReturn(serviceName);
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.updateOfficeService(OFFICE_ID, SERVICE_ID, json));
+    verify(namedJdbcTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
   }
 
   @Test
@@ -253,6 +387,46 @@ class OfficeExtensionWritePlatformServiceImplTest {
         .thenReturn(new java.math.BigDecimal("95.0"));
     when(fromJsonHelper.extractBigDecimalWithLocaleNamed("longitude", element))
         .thenReturn(new java.math.BigDecimal("-99.13"));
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.saveOfficeGeolocation(OFFICE_ID, json));
+  }
+
+  @Test
+  void saveOfficeGeolocation_longitudeAboveMaximum_throws() {
+    mockAuth();
+    when(jdbcTemplate.queryForObject(
+            eq("SELECT 1 FROM m_office WHERE id = ?"), eq(Integer.class), eq(OFFICE_ID)))
+        .thenReturn(1);
+
+    String json = "{\"latitude\":\"19.43\",\"longitude\":\"181.0\",\"locale\":\"en\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.extractBigDecimalWithLocaleNamed("latitude", element))
+        .thenReturn(new java.math.BigDecimal("19.43"));
+    when(fromJsonHelper.extractBigDecimalWithLocaleNamed("longitude", element))
+        .thenReturn(new java.math.BigDecimal("181.0"));
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> service.saveOfficeGeolocation(OFFICE_ID, json));
+  }
+
+  @Test
+  void saveOfficeGeolocation_longitudeBelowMinimum_throws() {
+    mockAuth();
+    when(jdbcTemplate.queryForObject(
+            eq("SELECT 1 FROM m_office WHERE id = ?"), eq(Integer.class), eq(OFFICE_ID)))
+        .thenReturn(1);
+
+    String json = "{\"latitude\":\"19.43\",\"longitude\":\"-181.0\",\"locale\":\"en\"}";
+    var element = new com.google.gson.JsonParser().parse(json);
+    when(fromJsonHelper.parse(json)).thenReturn(element);
+    when(fromJsonHelper.extractBigDecimalWithLocaleNamed("latitude", element))
+        .thenReturn(new java.math.BigDecimal("19.43"));
+    when(fromJsonHelper.extractBigDecimalWithLocaleNamed("longitude", element))
+        .thenReturn(new java.math.BigDecimal("-181.0"));
 
     assertThrows(
         PlatformApiDataValidationException.class,

--- a/src/test/java/org/apache/fineract/office/service/OfficeServiceLiquibaseAndCrudIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/office/service/OfficeServiceLiquibaseAndCrudIntegrationTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.office.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Collection;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.office.data.OfficeServiceData;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class OfficeServiceLiquibaseAndCrudIntegrationTest {
+
+  private static final String CHANGELOG =
+      "db/changelog/tenant/module/savings/parts/045-create-office-services-table.xml";
+
+  @Container
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:15-alpine");
+
+  private JdbcTemplate jdbcTemplate;
+  private NamedParameterJdbcTemplate namedJdbcTemplate;
+  private PlatformSecurityContext context;
+  private FromJsonHelper fromJsonHelper;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    final DriverManagerDataSource dataSource =
+        new DriverManagerDataSource(
+            POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.namedJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    this.context = mock(PlatformSecurityContext.class);
+    this.fromJsonHelper = mock(FromJsonHelper.class);
+
+    final AppUser user = mock(AppUser.class);
+    when(this.context.authenticatedUser()).thenReturn(user);
+
+    this.jdbcTemplate.execute("DROP TABLE IF EXISTS m_selfservice_office_service");
+    this.jdbcTemplate.execute("DROP TABLE IF EXISTS databasechangelog");
+    this.jdbcTemplate.execute("DROP TABLE IF EXISTS databasechangeloglock");
+    this.jdbcTemplate.execute("DROP TABLE IF EXISTS m_office");
+    this.jdbcTemplate.execute("CREATE TABLE m_office (id BIGINT PRIMARY KEY)");
+    this.jdbcTemplate.update("INSERT INTO m_office (id) VALUES (?)", 1L);
+
+    try (Connection connection =
+        DriverManager.getConnection(
+            POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())) {
+      final Database database =
+          DatabaseFactory.getInstance()
+              .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+      final Liquibase liquibase =
+          new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database);
+      liquibase.update(new Contexts(), new LabelExpression());
+    }
+  }
+
+  @Test
+  void officeServiceMigrationLoadsAndCrudWorks() {
+    assertTrue(tableExists("m_selfservice_office_service"));
+
+    final OfficeExtensionWritePlatformServiceImpl writeService =
+        new OfficeExtensionWritePlatformServiceImpl(
+            this.jdbcTemplate, this.namedJdbcTemplate, this.context, this.fromJsonHelper);
+    final OfficeExtensionReadPlatformServiceImpl readService =
+        new OfficeExtensionReadPlatformServiceImpl(this.jdbcTemplate, this.context);
+
+    final String createJson =
+        "{\"serviceName\":\"Cash Deposit\",\"serviceExternalId\":\"cash-deposit\",\"workingHours\":\"09:00-17:00\"}";
+    final JsonElement createElement = JsonParser.parseString(createJson);
+    when(this.fromJsonHelper.parse(createJson)).thenReturn(createElement);
+    when(this.fromJsonHelper.extractStringNamed("serviceName", createElement))
+        .thenReturn("Cash Deposit");
+    when(this.fromJsonHelper.extractStringNamed("serviceExternalId", createElement))
+        .thenReturn("cash-deposit");
+    when(this.fromJsonHelper.extractStringNamed("workingHours", createElement))
+        .thenReturn("09:00-17:00");
+
+    final CommandProcessingResult createResult = writeService.createOfficeService(1L, createJson);
+    final Long serviceId = createResult.getResourceId();
+    assertNotNull(serviceId);
+
+    Collection<OfficeServiceData> services = readService.retrieveOfficeServices(1L);
+    assertEquals(1, services.size());
+    OfficeServiceData service = services.iterator().next();
+    assertEquals("Cash Deposit", service.getServiceName());
+    assertEquals("cash-deposit", service.getServiceExternalId());
+    assertEquals("09:00-17:00", service.getWorkingHours());
+
+    final String updateJson = "{\"serviceName\":\"Cash Withdrawal\",\"workingHours\":\"10:00-16:00\"}";
+    final JsonElement updateElement = JsonParser.parseString(updateJson);
+    when(this.fromJsonHelper.parse(updateJson)).thenReturn(updateElement);
+    when(this.fromJsonHelper.parameterExists("serviceName", updateElement)).thenReturn(true);
+    when(this.fromJsonHelper.extractStringNamed("serviceName", updateElement))
+        .thenReturn("Cash Withdrawal");
+    when(this.fromJsonHelper.parameterExists("serviceExternalId", updateElement)).thenReturn(false);
+    when(this.fromJsonHelper.parameterExists("workingHours", updateElement)).thenReturn(true);
+    when(this.fromJsonHelper.extractStringNamed("workingHours", updateElement))
+        .thenReturn("10:00-16:00");
+
+    writeService.updateOfficeService(1L, serviceId, updateJson);
+    service = readService.retrieveOfficeService(serviceId);
+    assertEquals("Cash Withdrawal", service.getServiceName());
+    assertEquals("10:00-16:00", service.getWorkingHours());
+
+    writeService.deleteOfficeService(1L, serviceId);
+    services = readService.retrieveOfficeServices(1L);
+    assertFalse(services.iterator().hasNext());
+  }
+
+  private boolean tableExists(final String tableName) {
+    final Integer count =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = ?",
+            Integer.class,
+            tableName);
+    return count != null && count > 0;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database support for storing office services, including service names, external IDs, and working hours.
  * Added end-to-end create, update, retrieve, and delete support for office services.

* **Bug Fixes**
  * Office service creation and updates now reject missing or blank service names before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->