### PR TITLE
feat(WEB-1035): add exchange-rate provider sync 

### DIFF
--- a/src/main/java/org/apache/fineract/exchangerate/api/ExchangeRateApiResource.java
+++ b/src/main/java/org/apache/fineract/exchangerate/api/ExchangeRateApiResource.java
@@ -30,7 +30,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.exchangerate.data.CurrencyConversionData;
 import org.apache.fineract.exchangerate.data.ExchangeRateData;
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
 import org.apache.fineract.exchangerate.service.ExchangeRateReadPlatformService;
+import org.apache.fineract.exchangerate.service.ExchangeRateSynchronizationService;
 import org.apache.fineract.exchangerate.service.ExchangeRateWritePlatformService;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
@@ -51,6 +53,7 @@ public class ExchangeRateApiResource {
 
   private static final String RESOURCE_NAME_FOR_PERMISSIONS = "EXCHANGE_RATE";
   private static final String CONVERT_PERMISSION = "CONVERT_CURRENCY";
+  private static final String SYNC_PERMISSION = "SYNC_EXCHANGE_RATE";
   private static final String READ_EXCHANGE_RATE_PERMISSION =
       "hasAuthority('ALL_FUNCTIONS') or hasAuthority('READ_EXCHANGE_RATE')";
   private static final String CREATE_EXCHANGE_RATE_PERMISSION =
@@ -61,12 +64,17 @@ public class ExchangeRateApiResource {
       "hasAuthority('ALL_FUNCTIONS') or hasAuthority('DELETE_EXCHANGE_RATE')";
   private static final String CONVERT_CURRENCY_PERMISSION =
       "hasAuthority('ALL_FUNCTIONS') or hasAuthority('CONVERT_CURRENCY')";
+  private static final String SYNC_EXCHANGE_RATE_PERMISSION =
+      "hasAuthority('ALL_FUNCTIONS') or hasAuthority('SYNC_EXCHANGE_RATE')";
 
   private final PlatformSecurityContext context;
   private final ExchangeRateReadPlatformService readService;
   private final ExchangeRateWritePlatformService writeService;
+  private final ExchangeRateSynchronizationService synchronizationService;
   private final DefaultToApiJsonSerializer<ExchangeRateData> exchangeRateSerializer;
   private final DefaultToApiJsonSerializer<CurrencyConversionData> conversionSerializer;
+  private final DefaultToApiJsonSerializer<ExchangeRateSynchronizationResult>
+      synchronizationSerializer;
 
   @GET
   @Produces({MediaType.APPLICATION_JSON})
@@ -120,6 +128,29 @@ public class ExchangeRateApiResource {
     this.context.authenticatedUser().validateHasCreatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
     final CommandProcessingResult result = this.writeService.createExchangeRate(jsonBody);
     return this.exchangeRateSerializer.serializeResult(result);
+  }
+
+  /**
+   * Imports provider exchange rates for the requested base currency and returns the synchronization
+   * summary.
+   *
+   * @param jsonBody request body containing the optional base currency
+   * @return serialized synchronization summary
+   */
+  @POST
+  @Path("sync")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @PreAuthorize(SYNC_EXCHANGE_RATE_PERMISSION)
+  @Operation(
+      summary = "Synchronize Exchange Rates",
+      description = "Imports latest exchange rates from the configured external provider.")
+  @ApiResponse(responseCode = "200", description = "OK")
+  public String synchronizeExchangeRates(@Parameter(hidden = true) final String jsonBody) {
+    this.context.authenticatedUser().validateHasPermissionTo(SYNC_PERMISSION);
+    final ExchangeRateSynchronizationResult result =
+        this.synchronizationService.synchronize(jsonBody);
+    return this.synchronizationSerializer.serializeResult(result);
   }
 
   @PUT

--- a/src/main/java/org/apache/fineract/exchangerate/config/ExchangeRateProviderProperties.java
+++ b/src/main/java/org/apache/fineract/exchangerate/config/ExchangeRateProviderProperties.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/** Configuration for optional external exchange-rate provider synchronization. */
+@Component
+public class ExchangeRateProviderProperties {
+
+  private boolean providerEnabled;
+  private String provider = "frankfurter";
+  private String providerBaseUrl = "https://api.frankfurter.dev/v1";
+  private String baseCurrency = "USD";
+  private boolean syncEnabled;
+
+  public boolean isProviderEnabled() {
+    return this.providerEnabled;
+  }
+
+  @Value("${exchange-rate.provider.enabled:false}")
+  public void setProviderEnabled(final boolean providerEnabled) {
+    this.providerEnabled = providerEnabled;
+  }
+
+  public String getProvider() {
+    return this.provider;
+  }
+
+  @Value("${exchange-rate.provider:frankfurter}")
+  public void setProvider(final String provider) {
+    this.provider = provider;
+  }
+
+  public String getProviderBaseUrl() {
+    return this.providerBaseUrl;
+  }
+
+  @Value("${exchange-rate.provider.base-url:https://api.frankfurter.dev/v1}")
+  public void setProviderBaseUrl(final String providerBaseUrl) {
+    this.providerBaseUrl = providerBaseUrl;
+  }
+
+  public String getBaseCurrency() {
+    return this.baseCurrency;
+  }
+
+  @Value("${exchange-rate.base-currency:USD}")
+  public void setBaseCurrency(final String baseCurrency) {
+    this.baseCurrency = baseCurrency;
+  }
+
+  public boolean isSyncEnabled() {
+    return this.syncEnabled;
+  }
+
+  @Value("${exchange-rate.sync.enabled:false}")
+  public void setSyncEnabled(final boolean syncEnabled) {
+    this.syncEnabled = syncEnabled;
+  }
+}

--- a/src/main/java/org/apache/fineract/exchangerate/data/CurrencyConversionData.java
+++ b/src/main/java/org/apache/fineract/exchangerate/data/CurrencyConversionData.java
@@ -18,6 +18,8 @@ public final class CurrencyConversionData {
   private final BigDecimal sourceAmount;
   private final BigDecimal convertedAmount;
   private final LocalDate effectiveDate;
+  private final String rateSource;
+  private final String baseCurrency;
 
   private CurrencyConversionData(
       final String sourceCurrency,
@@ -25,13 +27,17 @@ public final class CurrencyConversionData {
       final BigDecimal exchangeRate,
       final BigDecimal sourceAmount,
       final BigDecimal convertedAmount,
-      final LocalDate effectiveDate) {
+      final LocalDate effectiveDate,
+      final String rateSource,
+      final String baseCurrency) {
     this.sourceCurrency = sourceCurrency;
     this.targetCurrency = targetCurrency;
     this.exchangeRate = exchangeRate;
     this.sourceAmount = sourceAmount;
     this.convertedAmount = convertedAmount;
     this.effectiveDate = effectiveDate;
+    this.rateSource = rateSource;
+    this.baseCurrency = baseCurrency;
   }
 
   /** Creates a conversion DTO for serialization. */
@@ -43,7 +49,35 @@ public final class CurrencyConversionData {
       final BigDecimal convertedAmount,
       final LocalDate effectiveDate) {
     return new CurrencyConversionData(
-        sourceCurrency, targetCurrency, exchangeRate, sourceAmount, convertedAmount, effectiveDate);
+        sourceCurrency,
+        targetCurrency,
+        exchangeRate,
+        sourceAmount,
+        convertedAmount,
+        effectiveDate,
+        null,
+        null);
+  }
+
+  /** Creates a conversion DTO with rate-source metadata for serialization. */
+  public static CurrencyConversionData instance(
+      final String sourceCurrency,
+      final String targetCurrency,
+      final BigDecimal exchangeRate,
+      final BigDecimal sourceAmount,
+      final BigDecimal convertedAmount,
+      final LocalDate effectiveDate,
+      final String rateSource,
+      final String baseCurrency) {
+    return new CurrencyConversionData(
+        sourceCurrency,
+        targetCurrency,
+        exchangeRate,
+        sourceAmount,
+        convertedAmount,
+        effectiveDate,
+        rateSource,
+        baseCurrency);
   }
 
   /** Returns the source currency code. */
@@ -74,5 +108,15 @@ public final class CurrencyConversionData {
   /** Returns the conversion date used to choose the rate. */
   public LocalDate getEffectiveDate() {
     return effectiveDate;
+  }
+
+  /** Returns DIRECT, PROVIDER, or CROSS_RATE when available. */
+  public String getRateSource() {
+    return rateSource;
+  }
+
+  /** Returns the configured base currency when a cross-rate conversion was used. */
+  public String getBaseCurrency() {
+    return baseCurrency;
   }
 }

--- a/src/main/java/org/apache/fineract/exchangerate/data/ExchangeRateSynchronizationResult.java
+++ b/src/main/java/org/apache/fineract/exchangerate/data/ExchangeRateSynchronizationResult.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** API response for external exchange-rate synchronization. */
+@Getter
+@RequiredArgsConstructor(staticName = "instance")
+public final class ExchangeRateSynchronizationResult {
+
+  private final int importedCount;
+  private final int skippedCount;
+  private final LocalDateTime timestamp;
+  private final String provider;
+  private final String baseCurrency;
+  private final LocalDate providerRateDate;
+}

--- a/src/main/java/org/apache/fineract/exchangerate/provider/ExchangeRateProvider.java
+++ b/src/main/java/org/apache/fineract/exchangerate/provider/ExchangeRateProvider.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.provider;
+
+/** Retrieves exchange rates from an external provider. */
+public interface ExchangeRateProvider {
+
+  String providerName();
+
+  ExchangeRateProviderResult fetchLatestRates(String baseCurrencyCode);
+}

--- a/src/main/java/org/apache/fineract/exchangerate/provider/ExchangeRateProviderResult.java
+++ b/src/main/java/org/apache/fineract/exchangerate/provider/ExchangeRateProviderResult.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.provider;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Normalized response returned by an external exchange-rate provider. */
+@Getter
+@RequiredArgsConstructor(staticName = "instance")
+public final class ExchangeRateProviderResult {
+
+  private final String provider;
+  private final String baseCurrencyCode;
+  private final LocalDate rateDate;
+  private final Map<String, BigDecimal> rates;
+}

--- a/src/main/java/org/apache/fineract/exchangerate/provider/FrankfurterExchangeRateProvider.java
+++ b/src/main/java/org/apache/fineract/exchangerate/provider/FrankfurterExchangeRateProvider.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.provider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** Frankfurter-backed exchange-rate provider. */
+@Component
+public class FrankfurterExchangeRateProvider implements ExchangeRateProvider {
+
+  public static final String PROVIDER_NAME = "frankfurter";
+
+  private final RestTemplate restTemplate;
+  private final ExchangeRateProviderProperties properties;
+
+  public FrankfurterExchangeRateProvider(
+      final RestTemplate restTemplate, final ExchangeRateProviderProperties properties) {
+    this.restTemplate = restTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public String providerName() {
+    return PROVIDER_NAME;
+  }
+
+  @Override
+  public ExchangeRateProviderResult fetchLatestRates(final String baseCurrencyCode) {
+    final URI uri =
+        UriComponentsBuilder.fromUriString(this.properties.getProviderBaseUrl())
+            .path("/latest")
+            .queryParam("base", baseCurrencyCode)
+            .build()
+            .toUri();
+
+    final FrankfurterLatestResponse response;
+    try {
+      response = this.restTemplate.getForObject(uri, FrankfurterLatestResponse.class);
+    } catch (final RestClientException e) {
+      throw validationError(
+          "validation.msg.exchangeRate.provider.unavailable",
+          "Exchange-rate provider is unavailable.",
+          e);
+    }
+
+    if (response == null
+        || response.getBase() == null
+        || response.getBase().isBlank()
+        || response.getDate() == null
+        || response.getRates() == null
+        || response.getRates().isEmpty()) {
+      throw validationError(
+          "validation.msg.exchangeRate.provider.response.invalid",
+          "Exchange-rate provider returned a malformed response.",
+          null);
+    }
+
+    final Map<String, BigDecimal> normalizedRates = new LinkedHashMap<>();
+    response
+        .getRates()
+        .forEach(
+            (currencyCode, rate) -> {
+              if (currencyCode == null
+                  || currencyCode.isBlank()
+                  || rate == null
+                  || rate.compareTo(BigDecimal.ZERO) <= 0) {
+                throw validationError(
+                    "validation.msg.exchangeRate.provider.response.invalid",
+                    "Exchange-rate provider returned a malformed response.",
+                    null);
+              }
+              normalizedRates.put(currencyCode.trim().toUpperCase(Locale.ROOT), rate);
+            });
+
+    return ExchangeRateProviderResult.instance(
+        PROVIDER_NAME,
+        response.getBase().trim().toUpperCase(Locale.ROOT),
+        response.getDate(),
+        normalizedRates);
+  }
+
+  private PlatformApiDataValidationException validationError(
+      final String code, final String message, final Throwable cause) {
+    final ApiParameterError error = ApiParameterError.generalError(code, message);
+    return cause == null
+        ? new PlatformApiDataValidationException(List.of(error))
+        : new PlatformApiDataValidationException(List.of(error), cause);
+  }
+
+  @Getter
+  @Setter
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static final class FrankfurterLatestResponse {
+
+    private String base;
+    private LocalDate date;
+    private Map<String, BigDecimal> rates;
+  }
+}

--- a/src/main/java/org/apache/fineract/exchangerate/scheduler/ExchangeRateSynchronizationScheduler.java
+++ b/src/main/java/org/apache/fineract/exchangerate/scheduler/ExchangeRateSynchronizationScheduler.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.exchangerate.service.ExchangeRateSynchronizationService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Optional scheduled synchronization for provider-backed exchange rates. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeRateSynchronizationScheduler {
+
+  private final ExchangeRateProviderProperties properties;
+  private final ExchangeRateSynchronizationService synchronizationService;
+
+  /** Runs provider synchronization for the configured base currency when scheduling is enabled. */
+  @Scheduled(cron = "${exchange-rate.sync.cron:0 0 18 * * *}")
+  public void synchronizeConfiguredBaseCurrency() {
+    if (!this.properties.isProviderEnabled() || !this.properties.isSyncEnabled()) {
+      log.debug("Exchange-rate synchronization is disabled. Skipping scheduler execution.");
+      return;
+    }
+
+    try {
+      this.synchronizationService.synchronizeBaseCurrency(this.properties.getBaseCurrency());
+    } catch (final RuntimeException e) {
+      log.warn("Exchange-rate synchronization failed: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateReadPlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateReadPlatformServiceImpl.java
@@ -15,9 +15,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
 import org.apache.fineract.exchangerate.data.CurrencyConversionCommand;
 import org.apache.fineract.exchangerate.data.CurrencyConversionData;
 import org.apache.fineract.exchangerate.data.ExchangeRateData;
@@ -31,6 +36,8 @@ import org.apache.fineract.organisation.monetary.domain.Money;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +49,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExchangeRateReadPlatformServiceImpl implements ExchangeRateReadPlatformService {
 
   private static final MathContext MONEY_CONTEXT = new MathContext(19, RoundingMode.HALF_UP);
+  private static final String RATE_SOURCE_DIRECT = "DIRECT";
+  private static final String RATE_SOURCE_PROVIDER = "PROVIDER";
+  private static final String RATE_SOURCE_CROSS_RATE = "CROSS_RATE";
   private static final String RESOURCE_NAME_FOR_PERMISSIONS = "EXCHANGE_RATE";
   private static final String CONVERT_PERMISSION = "CONVERT_CURRENCY";
   private static final String READ_EXCHANGE_RATE_PERMISSION =
@@ -50,8 +60,10 @@ public class ExchangeRateReadPlatformServiceImpl implements ExchangeRateReadPlat
       "hasAuthority('ALL_FUNCTIONS') or hasAuthority('CONVERT_CURRENCY')";
 
   private final JdbcTemplate jdbcTemplate;
+  private final NamedParameterJdbcTemplate namedJdbcTemplate;
   private final PlatformSecurityContext context;
   private final ExchangeRateDataValidator validator;
+  private final ExchangeRateProviderProperties properties;
 
   @Override
   @PreAuthorize(READ_EXCHANGE_RATE_PERMISSION)
@@ -126,56 +138,151 @@ public class ExchangeRateReadPlatformServiceImpl implements ExchangeRateReadPlat
   public CurrencyConversionData convert(final String jsonBody) {
     this.context.authenticatedUser().validateHasPermissionTo(CONVERT_PERMISSION);
     final CurrencyConversionCommand command = this.validator.validateConversion(jsonBody);
-    final ExchangeRateData exchangeRate =
-        retrieveActiveRate(
+    final ResolvedExchangeRate exchangeRate =
+        resolveExchangeRate(
             command.sourceCurrencyCode(), command.targetCurrencyCode(), command.conversionDate());
     final CurrencyData targetCurrency =
         this.validator.validateSupportedCurrency("targetCurrency", command.targetCurrencyCode());
     final BigDecimal convertedAmount =
         Money.of(
                 targetCurrency,
-                command.amount().multiply(exchangeRate.getExchangeRate(), MONEY_CONTEXT),
+                command.amount().multiply(exchangeRate.exchangeRate(), MONEY_CONTEXT),
                 MONEY_CONTEXT)
             .getAmount();
 
     return CurrencyConversionData.instance(
         command.sourceCurrencyCode(),
         command.targetCurrencyCode(),
-        exchangeRate.getExchangeRate(),
+        exchangeRate.exchangeRate(),
         command.amount(),
         convertedAmount,
-        command.conversionDate());
+        command.conversionDate(),
+        exchangeRate.rateSource(),
+        exchangeRate.baseCurrency());
   }
 
-  private ExchangeRateData retrieveActiveRate(
+  private ResolvedExchangeRate resolveExchangeRate(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    return retrieveDirectActiveRate(sourceCurrencyCode, targetCurrencyCode, date)
+        .orElseGet(() -> retrieveCrossRate(sourceCurrencyCode, targetCurrencyCode, date));
+  }
+
+  private Optional<ResolvedExchangeRate> retrieveDirectActiveRate(
       final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
     try {
-      return this.jdbcTemplate.queryForObject(
-          "SELECT id, source_currency_code, target_currency_code, exchange_rate,"
-              + " effective_from, effective_to, active, created_date, last_modified_date"
-              + " FROM m_exchange_rate"
-              + " WHERE source_currency_code = ? AND target_currency_code = ?"
-              + " AND active = true AND effective_from <= ?"
-              + " AND (effective_to IS NULL OR effective_to >= ?)"
-              + " ORDER BY effective_from DESC, id DESC LIMIT 1",
-          new ExchangeRateRowMapper(),
-          sourceCurrencyCode,
-          targetCurrencyCode,
-          date,
-          date);
+      return Optional.ofNullable(
+          this.jdbcTemplate.queryForObject(
+              "SELECT exchange_rate, provider"
+                  + " FROM m_exchange_rate"
+                  + " WHERE source_currency_code = ? AND target_currency_code = ?"
+                  + " AND active = true AND effective_from <= ?"
+                  + " AND (effective_to IS NULL OR effective_to >= ?)"
+                  + " ORDER BY CASE WHEN provider IS NULL THEN 0 ELSE 1 END,"
+                  + " effective_from DESC, id DESC LIMIT 1",
+              (rs, rowNum) ->
+                  new ResolvedExchangeRate(
+                      rs.getBigDecimal("exchange_rate"),
+                      rs.getString("provider") == null ? RATE_SOURCE_DIRECT : RATE_SOURCE_PROVIDER,
+                      null),
+              sourceCurrencyCode,
+              targetCurrencyCode,
+              date,
+              date));
     } catch (final EmptyResultDataAccessException e) {
-      final ApiParameterError error =
-          ApiParameterError.generalError(
-              "validation.msg.exchangeRate.not.found.for.conversion",
-              "No active exchange rate exists for "
-                  + sourceCurrencyCode
-                  + " to "
-                  + targetCurrencyCode
-                  + " on "
-                  + date
-                  + ".");
-      throw new PlatformApiDataValidationException(List.of(error));
+      return Optional.empty();
     }
+  }
+
+  private ResolvedExchangeRate retrieveCrossRate(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    final String baseCurrencyCode = normalizeCurrencyCode(this.properties.getBaseCurrency());
+    this.validator.validateSupportedCurrency("baseCurrency", baseCurrencyCode);
+
+    final Map<String, ResolvedExchangeRate> baseRates =
+        retrieveBaseRates(baseCurrencyCode, Set.of(sourceCurrencyCode, targetCurrencyCode), date);
+    final ResolvedExchangeRate sourceRate =
+        baseCurrencyCode.equals(sourceCurrencyCode)
+            ? new ResolvedExchangeRate(BigDecimal.ONE, RATE_SOURCE_DIRECT, null)
+            : baseRates.get(sourceCurrencyCode);
+    final ResolvedExchangeRate targetRate =
+        baseCurrencyCode.equals(targetCurrencyCode)
+            ? new ResolvedExchangeRate(BigDecimal.ONE, RATE_SOURCE_DIRECT, null)
+            : baseRates.get(targetCurrencyCode);
+
+    if (sourceRate == null || targetRate == null) {
+      throw noRateForConversion(sourceCurrencyCode, targetCurrencyCode, date);
+    }
+
+    return new ResolvedExchangeRate(
+        targetRate.exchangeRate().divide(sourceRate.exchangeRate(), MONEY_CONTEXT),
+        RATE_SOURCE_CROSS_RATE,
+        baseCurrencyCode);
+  }
+
+  private Map<String, ResolvedExchangeRate> retrieveBaseRates(
+      final String baseCurrencyCode,
+      final Set<String> requestedCurrencyCodes,
+      final LocalDate date) {
+    final Set<String> targetCurrencyCodes =
+        requestedCurrencyCodes.stream()
+            .filter(currencyCode -> !baseCurrencyCode.equals(currencyCode))
+            .collect(java.util.stream.Collectors.toSet());
+    if (targetCurrencyCodes.isEmpty()) {
+      return Map.of();
+    }
+
+    final MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("baseCurrencyCode", baseCurrencyCode)
+            .addValue("targetCurrencyCodes", targetCurrencyCodes)
+            .addValue("date", date);
+    final List<BaseRateRow> rows =
+        this.namedJdbcTemplate.query(
+            "SELECT target_currency_code, exchange_rate, provider"
+                + " FROM m_exchange_rate"
+                + " WHERE source_currency_code = :baseCurrencyCode"
+                + " AND target_currency_code IN (:targetCurrencyCodes)"
+                + " AND active = true AND effective_from <= :date"
+                + " AND (effective_to IS NULL OR effective_to >= :date)"
+                + " ORDER BY target_currency_code,"
+                + " CASE WHEN provider IS NULL THEN 0 ELSE 1 END,"
+                + " effective_from DESC, id DESC",
+            params,
+            (rs, rowNum) ->
+                new BaseRateRow(
+                    rs.getString("target_currency_code"),
+                    rs.getBigDecimal("exchange_rate"),
+                    rs.getString("provider")));
+
+    final Map<String, ResolvedExchangeRate> rates = new HashMap<>();
+    for (final BaseRateRow row : rows) {
+      rates.putIfAbsent(
+          row.targetCurrencyCode(),
+          new ResolvedExchangeRate(
+              row.exchangeRate(),
+              row.provider() == null ? RATE_SOURCE_DIRECT : RATE_SOURCE_PROVIDER,
+              null));
+    }
+    return rates;
+  }
+
+  private String normalizeCurrencyCode(final String currencyCode) {
+    return currencyCode == null ? null : currencyCode.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private PlatformApiDataValidationException noRateForConversion(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    final ApiParameterError error =
+        ApiParameterError.generalError(
+            "validation.msg.exchangeRate.not.found.for.conversion",
+            "No active exchange rate exists for "
+                + sourceCurrencyCode
+                + " to "
+                + targetCurrencyCode
+                + " on "
+                + date
+                + ".");
+    return new PlatformApiDataValidationException(List.of(error));
   }
 
   private void validateId(final Long exchangeRateId) {
@@ -221,4 +328,9 @@ public class ExchangeRateReadPlatformServiceImpl implements ExchangeRateReadPlat
           : null;
     }
   }
+
+  private record ResolvedExchangeRate(
+      BigDecimal exchangeRate, String rateSource, String baseCurrency) {}
+
+  private record BaseRateRow(String targetCurrencyCode, BigDecimal exchangeRate, String provider) {}
 }

--- a/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationService.java
+++ b/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationService.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.service;
+
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
+
+/** Synchronizes dynamic exchange rates from the configured external provider. */
+public interface ExchangeRateSynchronizationService {
+
+  ExchangeRateSynchronizationResult synchronize(String jsonBody);
+
+  ExchangeRateSynchronizationResult synchronizeBaseCurrency(String baseCurrencyCode);
+}

--- a/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationServiceImpl.java
+++ b/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationServiceImpl.java
@@ -1,0 +1,380 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.service;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProvider;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProviderResult;
+import org.apache.fineract.exchangerate.validation.ExchangeRateDataValidator;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Synchronizes provider-backed exchange rates into the existing dynamic exchange-rate table. */
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateSynchronizationServiceImpl implements ExchangeRateSynchronizationService {
+
+  private static final String SYNC_EXCHANGE_RATE_PERMISSION =
+      "hasAuthority('ALL_FUNCTIONS') or hasAuthority('SYNC_EXCHANGE_RATE')";
+
+  private final JdbcTemplate jdbcTemplate;
+  private final NamedParameterJdbcTemplate namedJdbcTemplate;
+  private final ExchangeRateProviderProperties properties;
+  private final List<ExchangeRateProvider> providers;
+  private final ExchangeRateDataValidator validator;
+
+  /** Validates and synchronizes provider exchange rates for an API-triggered request. */
+  @Override
+  @PreAuthorize(SYNC_EXCHANGE_RATE_PERMISSION)
+  @Transactional(transactionManager = "jdbcTransactionManager", isolation = Isolation.SERIALIZABLE)
+  public ExchangeRateSynchronizationResult synchronize(final String jsonBody) {
+    final String baseCurrencyCode =
+        this.validator.validateSynchronization(jsonBody, this.properties.getBaseCurrency());
+    return synchronizeBaseCurrency(baseCurrencyCode);
+  }
+
+  @Override
+  @Transactional(transactionManager = "jdbcTransactionManager", isolation = Isolation.SERIALIZABLE)
+  public ExchangeRateSynchronizationResult synchronizeBaseCurrency(final String baseCurrencyCode) {
+    if (!this.properties.isProviderEnabled()) {
+      throw validationError(
+          "validation.msg.exchangeRate.provider.disabled",
+          "Exchange-rate provider synchronization is disabled.");
+    }
+
+    final String normalizedBaseCurrency = normalizeCurrencyCode(baseCurrencyCode);
+    this.validator.validateSupportedCurrency("baseCurrency", normalizedBaseCurrency);
+
+    final ExchangeRateProvider provider = resolveProvider();
+    final ExchangeRateProviderResult providerResult =
+        provider.fetchLatestRates(normalizedBaseCurrency);
+    validateProviderResult(providerResult, normalizedBaseCurrency);
+
+    int importedCount = 0;
+    int skippedCount = 0;
+    final LocalDateTime now = LocalDateTime.now();
+    for (final var entry : providerResult.getRates().entrySet()) {
+      final String targetCurrencyCode = normalizeCurrencyCode(entry.getKey());
+      final BigDecimal exchangeRate = entry.getValue();
+      if (normalizedBaseCurrency.equals(targetCurrencyCode)
+          || exchangeRate == null
+          || exchangeRate.compareTo(BigDecimal.ZERO) <= 0
+          || !isSupportedCurrency(targetCurrencyCode)) {
+        skippedCount++;
+        continue;
+      }
+
+      if (saveProviderRateIfChanged(
+          providerResult.getProvider(),
+          normalizedBaseCurrency,
+          targetCurrencyCode,
+          exchangeRate,
+          providerResult.getRateDate(),
+          now)) {
+        importedCount++;
+      } else {
+        skippedCount++;
+      }
+    }
+
+    return ExchangeRateSynchronizationResult.instance(
+        importedCount,
+        skippedCount,
+        now,
+        providerResult.getProvider(),
+        normalizedBaseCurrency,
+        providerResult.getRateDate());
+  }
+
+  private ExchangeRateProvider resolveProvider() {
+    final String providerName = this.properties.getProvider();
+    return this.providers.stream()
+        .filter(provider -> provider.providerName().equalsIgnoreCase(providerName))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                validationError(
+                    "validation.msg.exchangeRate.provider.unsupported",
+                    "Exchange-rate provider " + providerName + " is not supported."));
+  }
+
+  private void validateProviderResult(
+      final ExchangeRateProviderResult providerResult, final String baseCurrencyCode) {
+    if (providerResult == null
+        || providerResult.getProvider() == null
+        || providerResult.getProvider().isBlank()
+        || providerResult.getBaseCurrencyCode() == null
+        || !baseCurrencyCode.equals(normalizeCurrencyCode(providerResult.getBaseCurrencyCode()))
+        || providerResult.getRateDate() == null
+        || providerResult.getRates() == null
+        || providerResult.getRates().isEmpty()) {
+      throw validationError(
+          "validation.msg.exchangeRate.provider.response.invalid",
+          "Exchange-rate provider returned a malformed response.");
+    }
+    providerResult
+        .getRates()
+        .forEach(
+            (currencyCode, exchangeRate) -> {
+              if (currencyCode == null
+                  || currencyCode.isBlank()
+                  || exchangeRate == null
+                  || exchangeRate.compareTo(BigDecimal.ZERO) <= 0) {
+                throw validationError(
+                    "validation.msg.exchangeRate.provider.response.invalid",
+                    "Exchange-rate provider returned a malformed response.");
+              }
+            });
+  }
+
+  private boolean saveProviderRateIfChanged(
+      final String provider,
+      final String sourceCurrencyCode,
+      final String targetCurrencyCode,
+      final BigDecimal exchangeRate,
+      final LocalDate effectiveFrom,
+      final LocalDateTime now) {
+    final Optional<ProviderExchangeRate> existingProviderRate =
+        findProviderRate(provider, sourceCurrencyCode, targetCurrencyCode, effectiveFrom);
+    if (existingProviderRate.isPresent()) {
+      if (existingProviderRate.get().exchangeRate().compareTo(exchangeRate) == 0) {
+        return false;
+      }
+      return updateProviderRate(existingProviderRate.get().id(), exchangeRate, now);
+    }
+
+    if (existsManualForEffectiveDate(sourceCurrencyCode, targetCurrencyCode, effectiveFrom)
+        || hasManualActiveRateOn(sourceCurrencyCode, targetCurrencyCode, effectiveFrom)
+        || hasFutureActiveRate(sourceCurrencyCode, targetCurrencyCode, effectiveFrom)) {
+      return false;
+    }
+
+    final Optional<ActiveExchangeRate> activeRate =
+        findActiveProviderRateOn(sourceCurrencyCode, targetCurrencyCode, effectiveFrom);
+    if (activeRate.isPresent()
+        && activeRate.get().exchangeRate().compareTo(exchangeRate) == 0
+        && activeRate.get().effectiveTo() == null) {
+      return false;
+    }
+
+    if (!insertProviderRate(
+        provider, sourceCurrencyCode, targetCurrencyCode, exchangeRate, effectiveFrom, now)) {
+      return false;
+    }
+    closePreviousActiveProviderRates(sourceCurrencyCode, targetCurrencyCode, effectiveFrom, now);
+    return true;
+  }
+
+  private Optional<ProviderExchangeRate> findProviderRate(
+      final String provider,
+      final String sourceCurrencyCode,
+      final String targetCurrencyCode,
+      final LocalDate providerRateDate) {
+    try {
+      return Optional.ofNullable(
+          this.jdbcTemplate.queryForObject(
+              "SELECT id, exchange_rate FROM m_exchange_rate WHERE provider = ?"
+                  + " AND provider_rate_date = ? AND source_currency_code = ?"
+                  + " AND target_currency_code = ?",
+              (rs, rowNum) ->
+                  new ProviderExchangeRate(rs.getLong("id"), rs.getBigDecimal("exchange_rate")),
+              provider,
+              providerRateDate,
+              sourceCurrencyCode,
+              targetCurrencyCode));
+    } catch (final EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  private boolean updateProviderRate(
+      final Long exchangeRateId, final BigDecimal exchangeRate, final LocalDateTime now) {
+    final int affectedRows =
+        this.jdbcTemplate.update(
+            "UPDATE m_exchange_rate SET exchange_rate = ?, last_synced_at = ?,"
+                + " last_modified_date = ? WHERE id = ?",
+            exchangeRate,
+            now,
+            now,
+            exchangeRateId);
+    return affectedRows > 0;
+  }
+
+  private boolean existsManualForEffectiveDate(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    final Long count =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM m_exchange_rate WHERE source_currency_code = ?"
+                + " AND target_currency_code = ? AND effective_from = ? AND provider IS NULL",
+            Long.class,
+            sourceCurrencyCode,
+            targetCurrencyCode,
+            date);
+    return count != null && count > 0;
+  }
+
+  private boolean hasManualActiveRateOn(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    final Long count =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM m_exchange_rate WHERE source_currency_code = ?"
+                + " AND target_currency_code = ? AND provider IS NULL"
+                + " AND active = true AND effective_from <= ?"
+                + " AND (effective_to IS NULL OR effective_to >= ?)",
+            Long.class,
+            sourceCurrencyCode,
+            targetCurrencyCode,
+            date,
+            date);
+    return count != null && count > 0;
+  }
+
+  private boolean hasFutureActiveRate(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    final Long count =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM m_exchange_rate WHERE source_currency_code = ?"
+                + " AND target_currency_code = ? AND active = true AND effective_from > ?",
+            Long.class,
+            sourceCurrencyCode,
+            targetCurrencyCode,
+            date);
+    return count != null && count > 0;
+  }
+
+  private Optional<ActiveExchangeRate> findActiveProviderRateOn(
+      final String sourceCurrencyCode, final String targetCurrencyCode, final LocalDate date) {
+    try {
+      return Optional.ofNullable(
+          this.jdbcTemplate.queryForObject(
+              "SELECT id, exchange_rate, effective_from, effective_to FROM m_exchange_rate"
+                  + " WHERE source_currency_code = ? AND target_currency_code = ?"
+                  + " AND provider IS NOT NULL"
+                  + " AND active = true AND effective_from <= ?"
+                  + " AND (effective_to IS NULL OR effective_to >= ?)"
+                  + " ORDER BY effective_from DESC, id DESC LIMIT 1",
+              new ActiveExchangeRateMapper(),
+              sourceCurrencyCode,
+              targetCurrencyCode,
+              date,
+              date));
+    } catch (final EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  private void closePreviousActiveProviderRates(
+      final String sourceCurrencyCode,
+      final String targetCurrencyCode,
+      final LocalDate effectiveFrom,
+      final LocalDateTime now) {
+    final MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("sourceCurrencyCode", sourceCurrencyCode)
+            .addValue("targetCurrencyCode", targetCurrencyCode)
+            .addValue("effectiveFrom", effectiveFrom)
+            .addValue("effectiveTo", effectiveFrom.minusDays(1))
+            .addValue("lastModifiedDate", now);
+    this.namedJdbcTemplate.update(
+        "UPDATE m_exchange_rate SET effective_to = :effectiveTo,"
+            + " last_modified_date = :lastModifiedDate"
+            + " WHERE source_currency_code = :sourceCurrencyCode"
+            + " AND target_currency_code = :targetCurrencyCode"
+            + " AND provider IS NOT NULL AND active = true AND effective_from < :effectiveFrom"
+            + " AND (effective_to IS NULL OR effective_to >= :effectiveFrom)",
+        params);
+  }
+
+  private boolean insertProviderRate(
+      final String provider,
+      final String sourceCurrencyCode,
+      final String targetCurrencyCode,
+      final BigDecimal exchangeRate,
+      final LocalDate effectiveFrom,
+      final LocalDateTime now) {
+    final MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("sourceCurrencyCode", sourceCurrencyCode)
+            .addValue("targetCurrencyCode", targetCurrencyCode)
+            .addValue("exchangeRate", exchangeRate)
+            .addValue("effectiveFrom", effectiveFrom)
+            .addValue("provider", provider)
+            .addValue("providerRateDate", effectiveFrom)
+            .addValue("lastSyncedAt", now)
+            .addValue("createdDate", now)
+            .addValue("lastModifiedDate", now);
+
+    final int affectedRows =
+        this.namedJdbcTemplate.update(
+            "INSERT INTO m_exchange_rate"
+                + " (source_currency_code, target_currency_code, exchange_rate, effective_from,"
+                + " effective_to, active, provider, provider_rate_date, last_synced_at,"
+                + " created_date, last_modified_date)"
+                + " VALUES (:sourceCurrencyCode, :targetCurrencyCode, :exchangeRate,"
+                + " :effectiveFrom, null, true, :provider, :providerRateDate, :lastSyncedAt,"
+                + " :createdDate, :lastModifiedDate)"
+                + " ON CONFLICT (source_currency_code, target_currency_code, effective_from)"
+                + " DO NOTHING",
+            params);
+    return affectedRows > 0;
+  }
+
+  private boolean isSupportedCurrency(final String currencyCode) {
+    try {
+      this.validator.validateSupportedCurrency("targetCurrency", currencyCode);
+      return true;
+    } catch (final PlatformApiDataValidationException e) {
+      return false;
+    }
+  }
+
+  private String normalizeCurrencyCode(final String currencyCode) {
+    return currencyCode == null ? null : currencyCode.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private PlatformApiDataValidationException validationError(
+      final String code, final String message) {
+    return new PlatformApiDataValidationException(
+        List.of(ApiParameterError.generalError(code, message)));
+  }
+
+  private record ActiveExchangeRate(
+      Long id, BigDecimal exchangeRate, LocalDate effectiveFrom, LocalDate effectiveTo) {}
+
+  private record ProviderExchangeRate(Long id, BigDecimal exchangeRate) {}
+
+  private static final class ActiveExchangeRateMapper implements RowMapper<ActiveExchangeRate> {
+
+    @Override
+    public ActiveExchangeRate mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+      return new ActiveExchangeRate(
+          rs.getLong("id"),
+          rs.getBigDecimal("exchange_rate"),
+          rs.getDate("effective_from").toLocalDate(),
+          rs.getDate("effective_to") != null ? rs.getDate("effective_to").toLocalDate() : null);
+    }
+  }
+}

--- a/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/exchangerate/service/ExchangeRateWritePlatformServiceImpl.java
@@ -59,7 +59,7 @@ public class ExchangeRateWritePlatformServiceImpl implements ExchangeRateWritePl
 
   @Override
   @PreAuthorize(CREATE_EXCHANGE_RATE_PERMISSION)
-  @Transactional(isolation = Isolation.SERIALIZABLE)
+  @Transactional(transactionManager = "jdbcTransactionManager", isolation = Isolation.SERIALIZABLE)
   public CommandProcessingResult createExchangeRate(final String jsonBody) {
     this.context.authenticatedUser().validateHasCreatePermission(RESOURCE_NAME_FOR_PERMISSIONS);
     final ExchangeRateCommand command = this.validator.validateCreate(jsonBody);
@@ -110,7 +110,7 @@ public class ExchangeRateWritePlatformServiceImpl implements ExchangeRateWritePl
 
   @Override
   @PreAuthorize(UPDATE_EXCHANGE_RATE_PERMISSION)
-  @Transactional(isolation = Isolation.SERIALIZABLE)
+  @Transactional(transactionManager = "jdbcTransactionManager", isolation = Isolation.SERIALIZABLE)
   public CommandProcessingResult updateExchangeRate(
       final Long exchangeRateId, final String jsonBody) {
     this.context.authenticatedUser().validateHasUpdatePermission(RESOURCE_NAME_FOR_PERMISSIONS);

--- a/src/main/java/org/apache/fineract/exchangerate/validation/ExchangeRateDataValidator.java
+++ b/src/main/java/org/apache/fineract/exchangerate/validation/ExchangeRateDataValidator.java
@@ -50,6 +50,7 @@ public class ExchangeRateDataValidator {
           "targetCurrency",
           "amount",
           "conversionDate");
+  private static final Set<String> SYNCHRONIZATION_PARAMETERS = Set.of("baseCurrency");
 
   private final FromJsonHelper fromJsonHelper;
   private final CurrencyReadPlatformService currencyReadPlatformService;
@@ -129,6 +130,28 @@ public class ExchangeRateDataValidator {
     validateSupportedCurrency("sourceCurrency", sourceCurrency);
     validateSupportedCurrency("targetCurrency", targetCurrency);
     return new CurrencyConversionCommand(sourceCurrency, targetCurrency, amount, conversionDate);
+  }
+
+  /** Validates an optional synchronization request and resolves the base tenant currency. */
+  public String validateSynchronization(final String jsonBody, final String defaultBaseCurrency) {
+    final String baseCurrency;
+    if (jsonBody == null || jsonBody.isBlank()) {
+      baseCurrency = normalizeCurrencyCode(defaultBaseCurrency);
+    } else {
+      final JsonElement element = this.fromJsonHelper.parse(jsonBody);
+      this.fromJsonHelper.checkForUnsupportedParameters(
+          element.getAsJsonObject(), SYNCHRONIZATION_PARAMETERS);
+      baseCurrency =
+          normalizeCurrencyCode(this.fromJsonHelper.extractStringNamed("baseCurrency", element));
+    }
+
+    final List<ApiParameterError> errors = new ArrayList<>();
+    final DataValidatorBuilder validator = new DataValidatorBuilder(errors).resource(RESOURCE_NAME);
+    validator.parameter("baseCurrency").value(baseCurrency).notBlank().notExceedingLengthOf(3);
+    throwIfErrors(errors);
+
+    validateSupportedCurrency("baseCurrency", baseCurrency);
+    return baseCurrency;
   }
 
   /** Returns configured currency metadata or raises a validation error for unsupported codes. */
@@ -213,6 +236,10 @@ public class ExchangeRateDataValidator {
     } else if (this.fromJsonHelper.parameterExists(aliasParameter, element)) {
       value = this.fromJsonHelper.extractStringNamed(aliasParameter, element);
     }
+    return value == null ? null : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private String normalizeCurrencyCode(final String value) {
     return value == null ? null : value.trim().toUpperCase(Locale.ROOT);
   }
 

--- a/src/main/resources/db/changelog/tenant/module/savings/module-changelog-master.xml
+++ b/src/main/resources/db/changelog/tenant/module/savings/module-changelog-master.xml
@@ -57,4 +57,5 @@
   <include file="parts/045-create-office-services-table.xml" relativeToChangelogFile="true"/>
   <include file="parts/046-create-office-working-hours-table.xml" relativeToChangelogFile="true"/>
   <include file="parts/047-create-dynamic-exchange-rates.xml" relativeToChangelogFile="true"/>
+  <include file="parts/048-add-exchange-rate-provider-sync.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenant/module/savings/parts/048-add-exchange-rate-provider-sync.xml
+++ b/src/main/resources/db/changelog/tenant/module/savings/parts/048-add-exchange-rate-provider-sync.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright since 2026 Mifos Initiative
+
+ <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="ss-048-1">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="m_exchange_rate"/>
+            <not>
+                <columnExists tableName="m_exchange_rate" columnName="provider"/>
+            </not>
+        </preConditions>
+
+        <comment>Add provider synchronization metadata to dynamic exchange rates</comment>
+
+        <addColumn tableName="m_exchange_rate">
+            <column name="provider" type="VARCHAR(50)"/>
+            <column name="provider_rate_date" type="DATE"/>
+            <column name="last_synced_at" type="TIMESTAMP"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-048-2">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="m_exchange_rate"/>
+            <not>
+                <indexExists indexName="idx_exchange_rate_provider_date"/>
+            </not>
+        </preConditions>
+
+        <comment>Add index for provider synchronization metadata</comment>
+
+        <createIndex indexName="idx_exchange_rate_provider_date" tableName="m_exchange_rate">
+            <column name="provider"/>
+            <column name="provider_rate_date"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-048-3">
+        <comment>Insert dynamic exchange-rate synchronization permission</comment>
+        <sql>
+            INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
+            SELECT 'portfolio', 'SYNC_EXCHANGE_RATE', 'EXCHANGE_RATE', 'SYNC', false
+            WHERE NOT EXISTS (SELECT 1 FROM m_permission WHERE code = 'SYNC_EXCHANGE_RATE');
+        </sql>
+    </changeSet>
+
+    <changeSet author="fineract" id="ss-048-4">
+        <comment>Assign exchange-rate synchronization permission to administrators</comment>
+        <sql>
+            INSERT INTO m_role_permission (role_id, permission_id)
+            SELECT r.id, p.id
+            FROM m_role r, m_permission p
+            WHERE r.name = 'Super user'
+            AND p.code = 'SYNC_EXCHANGE_RATE'
+            AND NOT EXISTS (
+                SELECT 1 FROM m_role_permission rp
+                WHERE rp.role_id = r.id AND rp.permission_id = p.id
+            );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/apache/fineract/exchangerate/api/ExchangeRateApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/exchangerate/api/ExchangeRateApiResourceTest.java
@@ -6,6 +6,7 @@
  */
 package org.apache.fineract.exchangerate.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -16,7 +17,9 @@ import java.time.LocalDate;
 import java.util.List;
 import org.apache.fineract.exchangerate.data.CurrencyConversionData;
 import org.apache.fineract.exchangerate.data.ExchangeRateData;
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
 import org.apache.fineract.exchangerate.service.ExchangeRateReadPlatformService;
+import org.apache.fineract.exchangerate.service.ExchangeRateSynchronizationService;
 import org.apache.fineract.exchangerate.service.ExchangeRateWritePlatformService;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
@@ -35,8 +38,12 @@ class ExchangeRateApiResourceTest {
   @Mock private PlatformSecurityContext context;
   @Mock private ExchangeRateReadPlatformService readService;
   @Mock private ExchangeRateWritePlatformService writeService;
+  @Mock private ExchangeRateSynchronizationService synchronizationService;
   @Mock private DefaultToApiJsonSerializer<ExchangeRateData> exchangeRateSerializer;
   @Mock private DefaultToApiJsonSerializer<CurrencyConversionData> conversionSerializer;
+
+  @Mock
+  private DefaultToApiJsonSerializer<ExchangeRateSynchronizationResult> synchronizationSerializer;
 
   private ExchangeRateApiResource resource;
 
@@ -47,8 +54,10 @@ class ExchangeRateApiResourceTest {
             this.context,
             this.readService,
             this.writeService,
+            this.synchronizationService,
             this.exchangeRateSerializer,
-            this.conversionSerializer);
+            this.conversionSerializer,
+            this.synchronizationSerializer);
   }
 
   @Test
@@ -141,6 +150,22 @@ class ExchangeRateApiResourceTest {
 
     verify(user).validateHasPermissionTo("CONVERT_CURRENCY");
     verify(this.readService).convert(jsonBody);
+  }
+
+  @Test
+  void synchronizeExchangeRatesRequiresSyncPermissionAndDelegates() {
+    final AppUser user = mockAuthenticatedUser();
+    final String jsonBody = "{\"baseCurrency\":\"USD\"}";
+    final ExchangeRateSynchronizationResult data =
+        ExchangeRateSynchronizationResult.instance(2, 1, null, "frankfurter", "USD", null);
+    when(this.synchronizationService.synchronize(jsonBody)).thenReturn(data);
+    when(this.synchronizationSerializer.serializeResult(data)).thenReturn("{}");
+
+    assertEquals("{}", this.resource.synchronizeExchangeRates(jsonBody));
+
+    verify(user).validateHasPermissionTo("SYNC_EXCHANGE_RATE");
+    verify(this.synchronizationService).synchronize(jsonBody);
+    verify(this.synchronizationSerializer).serializeResult(data);
   }
 
   private AppUser mockAuthenticatedUser() {

--- a/src/test/java/org/apache/fineract/exchangerate/provider/FrankfurterExchangeRateProviderTest.java
+++ b/src/test/java/org/apache/fineract/exchangerate/provider/FrankfurterExchangeRateProviderTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Map;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+class FrankfurterExchangeRateProviderTest {
+
+  @Test
+  void fetchLatestRatesNormalizesValidProviderResponse() {
+    final RestTemplate restTemplate = mock(RestTemplate.class);
+    final ExchangeRateProviderProperties properties = providerProperties();
+    final FrankfurterExchangeRateProvider.FrankfurterLatestResponse response =
+        new FrankfurterExchangeRateProvider.FrankfurterLatestResponse();
+    response.setBase("usd");
+    response.setDate(LocalDate.parse("2026-07-25"));
+    response.setRates(Map.of("eur", new BigDecimal("0.850000000000")));
+    when(restTemplate.getForObject(
+            any(URI.class), eq(FrankfurterExchangeRateProvider.FrankfurterLatestResponse.class)))
+        .thenReturn(response);
+
+    final ExchangeRateProviderResult result =
+        new FrankfurterExchangeRateProvider(restTemplate, properties).fetchLatestRates("USD");
+
+    assertEquals("frankfurter", result.getProvider());
+    assertEquals("USD", result.getBaseCurrencyCode());
+    assertEquals(LocalDate.parse("2026-07-25"), result.getRateDate());
+    assertEquals(new BigDecimal("0.850000000000"), result.getRates().get("EUR"));
+  }
+
+  @Test
+  void fetchLatestRatesRejectsMalformedProviderResponse() {
+    final RestTemplate restTemplate = mock(RestTemplate.class);
+    final FrankfurterExchangeRateProvider.FrankfurterLatestResponse response =
+        new FrankfurterExchangeRateProvider.FrankfurterLatestResponse();
+    response.setBase("USD");
+    response.setDate(LocalDate.parse("2026-07-25"));
+    response.setRates(Map.of("EUR", BigDecimal.ZERO));
+    when(restTemplate.getForObject(
+            any(URI.class), eq(FrankfurterExchangeRateProvider.FrankfurterLatestResponse.class)))
+        .thenReturn(response);
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () ->
+            new FrankfurterExchangeRateProvider(restTemplate, providerProperties())
+                .fetchLatestRates("USD"));
+  }
+
+  @Test
+  void fetchLatestRatesHandlesProviderUnavailable() {
+    final RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(
+            any(URI.class), eq(FrankfurterExchangeRateProvider.FrankfurterLatestResponse.class)))
+        .thenThrow(new ResourceAccessException("timeout"));
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () ->
+            new FrankfurterExchangeRateProvider(restTemplate, providerProperties())
+                .fetchLatestRates("USD"));
+  }
+
+  private ExchangeRateProviderProperties providerProperties() {
+    final ExchangeRateProviderProperties properties = new ExchangeRateProviderProperties();
+    properties.setProviderBaseUrl("https://api.frankfurter.dev/v1");
+    return properties;
+  }
+}

--- a/src/test/java/org/apache/fineract/exchangerate/scheduler/ExchangeRateSynchronizationSchedulerTest.java
+++ b/src/test/java/org/apache/fineract/exchangerate/scheduler/ExchangeRateSynchronizationSchedulerTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.scheduler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.exchangerate.service.ExchangeRateSynchronizationService;
+import org.junit.jupiter.api.Test;
+
+class ExchangeRateSynchronizationSchedulerTest {
+
+  @Test
+  void schedulerDoesNothingWhenSynchronizationIsDisabled() {
+    final ExchangeRateProviderProperties properties = new ExchangeRateProviderProperties();
+    final ExchangeRateSynchronizationService synchronizationService =
+        mock(ExchangeRateSynchronizationService.class);
+
+    new ExchangeRateSynchronizationScheduler(properties, synchronizationService)
+        .synchronizeConfiguredBaseCurrency();
+
+    verifyNoInteractions(synchronizationService);
+  }
+
+  @Test
+  void schedulerSynchronizesConfiguredBaseCurrencyWhenEnabled() {
+    final ExchangeRateProviderProperties properties = new ExchangeRateProviderProperties();
+    properties.setProviderEnabled(true);
+    properties.setSyncEnabled(true);
+    properties.setBaseCurrency("USD");
+    final ExchangeRateSynchronizationService synchronizationService =
+        mock(ExchangeRateSynchronizationService.class);
+
+    new ExchangeRateSynchronizationScheduler(properties, synchronizationService)
+        .synchronizeConfiguredBaseCurrency();
+
+    verify(synchronizationService).synchronizeBaseCurrency("USD");
+  }
+}

--- a/src/test/java/org/apache/fineract/exchangerate/service/ExchangeRateLiquibaseAndCrudIntegrationTest.java
+++ b/src/test/java/org/apache/fineract/exchangerate/service/ExchangeRateLiquibaseAndCrudIntegrationTest.java
@@ -8,6 +8,7 @@ package org.apache.fineract.exchangerate.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -29,8 +32,12 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
 import org.apache.fineract.exchangerate.data.CurrencyConversionData;
 import org.apache.fineract.exchangerate.data.ExchangeRateData;
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProvider;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProviderResult;
 import org.apache.fineract.exchangerate.validation.ExchangeRateDataValidator;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
@@ -54,6 +61,8 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
 
   private static final String CHANGELOG =
       "db/changelog/tenant/module/savings/parts/047-create-dynamic-exchange-rates.xml";
+  private static final String SYNC_CHANGELOG =
+      "db/changelog/tenant/module/savings/parts/048-add-exchange-rate-provider-sync.xml";
 
   @Container
   private static final PostgreSQLContainer<?> POSTGRES =
@@ -85,7 +94,12 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
         new ExchangeRateDataValidator(
             new FromJsonHelper(), new CurrencyReadPlatformServiceImpl(this.jdbcTemplate));
     this.readService =
-        new ExchangeRateReadPlatformServiceImpl(this.jdbcTemplate, this.context, validator);
+        new ExchangeRateReadPlatformServiceImpl(
+            this.jdbcTemplate,
+            this.namedJdbcTemplate,
+            this.context,
+            validator,
+            providerProperties(true));
     this.writeService =
         new ExchangeRateWritePlatformServiceImpl(
             this.jdbcTemplate, this.namedJdbcTemplate, this.context, validator);
@@ -160,7 +174,7 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
                 rateJson("ZZZ", "JPY", "156.000000000000", "2026-06-01", null, true)));
     assertThrows(
         PlatformApiDataValidationException.class,
-        () -> this.readService.convert(conversionJson("JPY", "USD", "10", "2026-07-25")));
+        () -> this.readService.convert(conversionJson("KWD", "XOF", "10", "2026-07-25")));
     assertThrows(
         PlatformApiDataValidationException.class,
         () ->
@@ -217,11 +231,13 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
     assertPermissionExists("UPDATE_EXCHANGE_RATE");
     assertPermissionExists("DELETE_EXCHANGE_RATE");
     assertPermissionExists("CONVERT_CURRENCY");
+    assertPermissionExists("SYNC_EXCHANGE_RATE");
     assertRoleHasPermission("Super user", "READ_EXCHANGE_RATE");
     assertRoleHasPermission("Super user", "CREATE_EXCHANGE_RATE");
     assertRoleHasPermission("Super user", "UPDATE_EXCHANGE_RATE");
     assertRoleHasPermission("Super user", "DELETE_EXCHANGE_RATE");
     assertRoleHasPermission("Super user", "CONVERT_CURRENCY");
+    assertRoleHasPermission("Super user", "SYNC_EXCHANGE_RATE");
     assertRoleHasPermission("Self Service User", "READ_EXCHANGE_RATE");
     assertRoleHasPermission("Self Service User", "CONVERT_CURRENCY");
 
@@ -237,6 +253,238 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
                 "JPY",
                 new BigDecimal("-1.00"),
                 LocalDate.parse("2026-01-01")));
+  }
+
+  @Test
+  void synchronizationPreservesHistorySkipsUnchangedRatesAndStoresProviderMetadata() {
+    final ExchangeRateProvider provider = mock(ExchangeRateProvider.class);
+    when(provider.providerName()).thenReturn("frankfurter");
+    when(provider.fetchLatestRates("USD"))
+        .thenReturn(
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-01-01"),
+                rates(
+                    "JPY",
+                    new BigDecimal("150.000000000000"),
+                    "KWD",
+                    new BigDecimal("0.305000000000"),
+                    "ZZZ",
+                    new BigDecimal("1.500000000000"))),
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-07-25"),
+                rates(
+                    "JPY",
+                    new BigDecimal("155.125000000000"),
+                    "KWD",
+                    new BigDecimal("0.305000000000"),
+                    "ZZZ",
+                    new BigDecimal("1.500000000000"))));
+
+    final ExchangeRateSynchronizationServiceImpl synchronizationService =
+        new ExchangeRateSynchronizationServiceImpl(
+            this.jdbcTemplate,
+            this.namedJdbcTemplate,
+            providerProperties(true),
+            List.of(provider),
+            new ExchangeRateDataValidator(
+                new FromJsonHelper(), new CurrencyReadPlatformServiceImpl(this.jdbcTemplate)));
+
+    final ExchangeRateSynchronizationResult firstResult =
+        synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}");
+
+    assertEquals(2, firstResult.getImportedCount());
+    assertEquals(1, firstResult.getSkippedCount());
+    assertEquals(LocalDate.parse("2026-01-01"), firstResult.getProviderRateDate());
+
+    final ExchangeRateSynchronizationResult secondResult =
+        synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}");
+
+    assertEquals(1, secondResult.getImportedCount());
+    assertEquals(2, secondResult.getSkippedCount());
+    assertEquals(LocalDate.parse("2026-07-25"), secondResult.getProviderRateDate());
+
+    final Collection<ExchangeRateData> currentJpyRates =
+        this.readService.retrieveAll("USD", "JPY", true, LocalDate.parse("2026-07-25"));
+    assertEquals(1, currentJpyRates.size());
+    assertEquals(
+        new BigDecimal("155.125000000000"), currentJpyRates.iterator().next().getExchangeRate());
+
+    final LocalDate closedHistoricalTo =
+        this.jdbcTemplate.queryForObject(
+            "SELECT effective_to FROM m_exchange_rate WHERE source_currency_code = ?"
+                + " AND target_currency_code = ? AND effective_from = ?",
+            LocalDate.class,
+            "USD",
+            "JPY",
+            LocalDate.parse("2026-01-01"));
+    assertEquals(LocalDate.parse("2026-07-24"), closedHistoricalTo);
+
+    final Integer providerRows =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM m_exchange_rate WHERE source_currency_code = ?"
+                + " AND target_currency_code = ? AND provider = ?"
+                + " AND provider_rate_date = ? AND last_synced_at IS NOT NULL",
+            Integer.class,
+            "USD",
+            "JPY",
+            "frankfurter",
+            LocalDate.parse("2026-07-25"));
+    assertEquals(1, providerRows);
+
+    final CurrencyConversionData historicalConversion =
+        this.readService.convert(conversionJson("USD", "JPY", "1", "2026-07-20"));
+    assertEquals(new BigDecimal("150"), historicalConversion.getConvertedAmount());
+  }
+
+  @Test
+  void directAndCrossRateConversionsRespectHistoryAndManualOverride() {
+    final ExchangeRateProvider provider = mock(ExchangeRateProvider.class);
+    when(provider.providerName()).thenReturn("frankfurter");
+    when(provider.fetchLatestRates("USD"))
+        .thenReturn(
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-01-01"),
+                rates(
+                    "AOA",
+                    new BigDecimal("900.000000000000"),
+                    "DZD",
+                    new BigDecimal("120.000000000000"),
+                    "EUR",
+                    new BigDecimal("0.900000000000"))),
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-07-25"),
+                rates(
+                    "AOA",
+                    new BigDecimal("920.000000000000"),
+                    "DZD",
+                    new BigDecimal("135.000000000000"),
+                    "EUR",
+                    new BigDecimal("0.850000000000"))));
+
+    final ExchangeRateSynchronizationServiceImpl synchronizationService =
+        new ExchangeRateSynchronizationServiceImpl(
+            this.jdbcTemplate,
+            this.namedJdbcTemplate,
+            providerProperties(true),
+            List.of(provider),
+            new ExchangeRateDataValidator(
+                new FromJsonHelper(), new CurrencyReadPlatformServiceImpl(this.jdbcTemplate)));
+    synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}");
+    synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}");
+
+    final CurrencyConversionData directProviderConversion =
+        this.readService.convert(conversionJson("USD", "EUR", "100", "2026-07-25"));
+    assertEquals(new BigDecimal("85.00"), directProviderConversion.getConvertedAmount());
+    assertEquals("PROVIDER", directProviderConversion.getRateSource());
+    assertNull(directProviderConversion.getBaseCurrency());
+
+    final CurrencyConversionData crossRateConversion =
+        this.readService.convert(conversionJson("AOA", "DZD", "920", "2026-07-25"));
+    assertEquals(new BigDecimal("135.00"), crossRateConversion.getConvertedAmount());
+    assertEquals("CROSS_RATE", crossRateConversion.getRateSource());
+    assertEquals("USD", crossRateConversion.getBaseCurrency());
+
+    final CurrencyConversionData historicalCrossRateConversion =
+        this.readService.convert(conversionJson("AOA", "DZD", "900", "2026-01-15"));
+    assertEquals(new BigDecimal("120.00"), historicalCrossRateConversion.getConvertedAmount());
+    assertEquals("CROSS_RATE", historicalCrossRateConversion.getRateSource());
+
+    this.writeService.createExchangeRate(
+        rateJson("AOA", "DZD", "0.200000000000", "2026-01-01", null, true));
+    final CurrencyConversionData manualOverrideConversion =
+        this.readService.convert(conversionJson("AOA", "DZD", "100", "2026-07-25"));
+    assertEquals(new BigDecimal("20.00"), manualOverrideConversion.getConvertedAmount());
+    assertEquals("DIRECT", manualOverrideConversion.getRateSource());
+    assertNull(manualOverrideConversion.getBaseCurrency());
+  }
+
+  @Test
+  void synchronizationUpdatesExistingProviderRowsWithoutDuplicatingThem() {
+    final ExchangeRateProvider provider = mock(ExchangeRateProvider.class);
+    when(provider.providerName()).thenReturn("frankfurter");
+    when(provider.fetchLatestRates("USD"))
+        .thenReturn(
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-07-25"),
+                rates(
+                    "AOA",
+                    new BigDecimal("920.000000000000"),
+                    "DZD",
+                    new BigDecimal("135.000000000000"),
+                    "EUR",
+                    new BigDecimal("0.850000000000"))),
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-07-25"),
+                rates(
+                    "AOA",
+                    new BigDecimal("930.000000000000"),
+                    "DZD",
+                    new BigDecimal("135.000000000000"),
+                    "EUR",
+                    new BigDecimal("0.850000000000"))));
+
+    final ExchangeRateSynchronizationServiceImpl synchronizationService =
+        new ExchangeRateSynchronizationServiceImpl(
+            this.jdbcTemplate,
+            this.namedJdbcTemplate,
+            providerProperties(true),
+            List.of(provider),
+            new ExchangeRateDataValidator(
+                new FromJsonHelper(), new CurrencyReadPlatformServiceImpl(this.jdbcTemplate)));
+
+    assertEquals(
+        3, synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}").getImportedCount());
+    final ExchangeRateSynchronizationResult secondResult =
+        synchronizationService.synchronize("{\"baseCurrency\":\"USD\"}");
+    assertEquals(1, secondResult.getImportedCount());
+    assertEquals(2, secondResult.getSkippedCount());
+
+    final Integer providerRows =
+        this.jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM m_exchange_rate WHERE provider = ?"
+                + " AND provider_rate_date = ?",
+            Integer.class,
+            "frankfurter",
+            LocalDate.parse("2026-07-25"));
+    assertEquals(3, providerRows);
+
+    final BigDecimal updatedAoaRate =
+        this.jdbcTemplate.queryForObject(
+            "SELECT exchange_rate FROM m_exchange_rate WHERE provider = ?"
+                + " AND source_currency_code = ? AND target_currency_code = ?"
+                + " AND provider_rate_date = ?",
+            BigDecimal.class,
+            "frankfurter",
+            "USD",
+            "AOA",
+            LocalDate.parse("2026-07-25"));
+    assertEquals(0, new BigDecimal("930.000000000000").compareTo(updatedAoaRate));
+
+    final CurrencyConversionData crossRateConversion =
+        this.readService.convert(conversionJson("AOA", "DZD", "930", "2026-07-25"));
+    assertEquals(new BigDecimal("135.00"), crossRateConversion.getConvertedAmount());
+  }
+
+  @Test
+  void crossRateConversionStillRejectsUnsupportedCurrency() {
+    this.writeService.createExchangeRate(
+        rateJson("USD", "AOA", "920.000000000000", "2026-01-01", null, true));
+
+    assertThrows(
+        PlatformApiDataValidationException.class,
+        () -> this.readService.convert(conversionJson("AOA", "ZZZ", "10", "2026-07-25")));
   }
 
   private void resetSchema() {
@@ -277,38 +525,57 @@ class ExchangeRateLiquibaseAndCrudIntegrationTest {
       final Liquibase liquibase =
           new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database);
       liquibase.update(new Contexts(), new LabelExpression());
+      final Liquibase syncLiquibase =
+          new Liquibase(SYNC_CHANGELOG, new ClassLoaderResourceAccessor(), database);
+      syncLiquibase.update(new Contexts(), new LabelExpression());
     }
   }
 
+  private ExchangeRateProviderProperties providerProperties(final boolean enabled) {
+    final ExchangeRateProviderProperties properties = new ExchangeRateProviderProperties();
+    properties.setProviderEnabled(enabled);
+    properties.setProvider("frankfurter");
+    properties.setProviderBaseUrl("https://api.frankfurter.dev/v1");
+    properties.setBaseCurrency("USD");
+    return properties;
+  }
+
+  private Map<String, BigDecimal> rates(
+      final String firstCurrency,
+      final BigDecimal firstRate,
+      final String secondCurrency,
+      final BigDecimal secondRate,
+      final String thirdCurrency,
+      final BigDecimal thirdRate) {
+    final Map<String, BigDecimal> rates = new LinkedHashMap<>();
+    rates.put(firstCurrency, firstRate);
+    rates.put(secondCurrency, secondRate);
+    rates.put(thirdCurrency, thirdRate);
+    return rates;
+  }
+
   private void seedCurrencies() {
+    insertCurrency("USD", "US Dollar", 2, "$");
+    insertCurrency("JPY", "Japanese Yen", 0, "JPY");
+    insertCurrency("KWD", "Kuwaiti Dinar", 3, "KD");
+    insertCurrency("XOF", "CFA Franc BCEAO", 0, "CFA");
+    insertCurrency("EUR", "Euro", 2, "EUR");
+    insertCurrency("AOA", "Angolan Kwanza", 2, "AOA");
+    insertCurrency("DZD", "Algerian Dinar", 2, "DZD");
+  }
+
+  private void insertCurrency(
+      final String code, final String name, final int decimalPlaces, final String displaySymbol) {
     this.jdbcTemplate.update(
         "INSERT INTO m_currency"
             + " (code, name, decimal_places, currency_multiplesof, display_symbol, internationalized_name_code)"
-            + " VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)",
-        "USD",
-        "US Dollar",
-        2,
+            + " VALUES (?, ?, ?, ?, ?, ?)",
+        code,
+        name,
+        decimalPlaces,
         null,
-        "$",
-        "currency.USD",
-        "JPY",
-        "Japanese Yen",
-        0,
-        null,
-        "JPY",
-        "currency.JPY",
-        "KWD",
-        "Kuwaiti Dinar",
-        3,
-        null,
-        "KD",
-        "currency.KWD",
-        "XOF",
-        "CFA Franc BCEAO",
-        0,
-        null,
-        "CFA",
-        "currency.XOF");
+        displaySymbol,
+        "currency." + code);
   }
 
   private boolean tableExists(final String tableName) {

--- a/src/test/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/exchangerate/service/ExchangeRateSynchronizationServiceImplTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+ * of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.apache.fineract.exchangerate.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.exchangerate.config.ExchangeRateProviderProperties;
+import org.apache.fineract.exchangerate.data.ExchangeRateSynchronizationResult;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProvider;
+import org.apache.fineract.exchangerate.provider.ExchangeRateProviderResult;
+import org.apache.fineract.exchangerate.validation.ExchangeRateDataValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+class ExchangeRateSynchronizationServiceImplTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void synchronizationSkipsCurrencyWhenProviderInsertFindsConflict() {
+    final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    final NamedParameterJdbcTemplate namedJdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+    final ExchangeRateProvider provider = mock(ExchangeRateProvider.class);
+    final ExchangeRateDataValidator validator = mock(ExchangeRateDataValidator.class);
+    when(validator.validateSynchronization("{\"baseCurrency\":\"USD\"}", "USD")).thenReturn("USD");
+    when(provider.providerName()).thenReturn("frankfurter");
+    when(provider.fetchLatestRates("USD"))
+        .thenReturn(
+            ExchangeRateProviderResult.instance(
+                "frankfurter",
+                "USD",
+                LocalDate.parse("2026-07-25"),
+                Map.of("EUR", new BigDecimal("0.850000000000"))));
+    when(jdbcTemplate.queryForObject(
+            startsWith("SELECT id, exchange_rate FROM m_exchange_rate"),
+            any(RowMapper.class),
+            eq("frankfurter"),
+            eq(LocalDate.parse("2026-07-25")),
+            eq("USD"),
+            eq("EUR")))
+        .thenThrow(new EmptyResultDataAccessException(1));
+    when(jdbcTemplate.queryForObject(startsWith("SELECT COUNT(*)"), eq(Long.class), any()))
+        .thenReturn(0L);
+    when(jdbcTemplate.queryForObject(
+            startsWith("SELECT id, exchange_rate, effective_from, effective_to"),
+            any(RowMapper.class),
+            eq("USD"),
+            eq("EUR"),
+            eq(LocalDate.parse("2026-07-25")),
+            eq(LocalDate.parse("2026-07-25"))))
+        .thenThrow(new EmptyResultDataAccessException(1));
+    when(namedJdbcTemplate.update(
+            startsWith("INSERT INTO m_exchange_rate"), any(MapSqlParameterSource.class)))
+        .thenReturn(0);
+
+    final ExchangeRateSynchronizationServiceImpl service =
+        new ExchangeRateSynchronizationServiceImpl(
+            jdbcTemplate, namedJdbcTemplate, providerProperties(), List.of(provider), validator);
+
+    final ExchangeRateSynchronizationResult result =
+        service.synchronize("{\"baseCurrency\":\"USD\"}");
+
+    assertEquals(0, result.getImportedCount());
+    assertEquals(1, result.getSkippedCount());
+    verify(namedJdbcTemplate, never())
+        .update(
+            startsWith("UPDATE m_exchange_rate SET effective_to"),
+            any(MapSqlParameterSource.class));
+  }
+
+  private ExchangeRateProviderProperties providerProperties() {
+    final ExchangeRateProviderProperties properties = new ExchangeRateProviderProperties();
+    properties.setProviderEnabled(true);
+    properties.setProvider("frankfurter");
+    properties.setBaseCurrency("USD");
+    return properties;
+  }
+}


### PR DESCRIPTION
This is a continuation PR for WEB-1035 that adds automatic synchronization to fetch and use the latest currency exchange rates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exchange-rate synchronization through an authenticated API endpoint.
  * Added optional external-provider support with configurable provider, base currency, and synchronization schedule.
  * Added automatic daily synchronization when enabled.
  * Exchange-rate conversions now support provider metadata and cross-rate calculations.

* **Bug Fixes**
  * Preserves manual rates and avoids duplicate provider rates during synchronization.

* **Documentation**
  * Added database support for provider details, synchronization timestamps, and related permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->