### PR TITLE
fix(WEB-1109): expose linked phones for savings accounts

### DIFF
--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/api/SinpeEnrollmentApiResource.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/api/SinpeEnrollmentApiResource.java
@@ -12,8 +12,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.fastpayment.sinpe.data.SinpeLinkedPhoneData;
 import org.apache.fineract.fastpayment.sinpe.data.SinpePhoneStatusData;
 import org.apache.fineract.fastpayment.sinpe.data.SinpeSubscriptionEditRequest;
 import org.apache.fineract.fastpayment.sinpe.service.SinpeEnrollmentReadPlatformService;
@@ -48,6 +50,10 @@ public final class SinpeEnrollmentApiResource {
   /** Serializer for phone status responses. */
   private final DefaultToApiJsonSerializer<SinpePhoneStatusData>
       phoneStatusSerializer;
+
+  /** Serializer for linked phone responses. */
+  private final DefaultToApiJsonSerializer<SinpeLinkedPhoneData>
+      linkedPhoneSerializer;
 
   /**
    * Starts the existing SINPE phone OTP request flow.
@@ -251,6 +257,28 @@ public final class SinpeEnrollmentApiResource {
     SinpePhoneStatusData data =
         readPlatformService.retrievePhoneStatus(phoneNumber);
     return phoneStatusSerializer.serialize(data);
+  }
+
+  /**
+   * Retrieves active local phone links for a savings account.
+   *
+   * @param savingsAccountId savings account identifier
+   * @return serialized linked phone data
+   */
+  @GET
+  @Path("/savingsaccounts/{savingsAccountId}/phones")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "List linked SINPE Móvil phones for savings account",
+      description = "Returns active local SINPE phone links for a savings account.")
+  public String retrieveLinkedPhones(
+      @PathParam("savingsAccountId") final Long savingsAccountId) {
+    context.authenticatedUser()
+        .validateHasPermissionTo("READ_SINPE_ENROLLMENT");
+
+    Collection<SinpeLinkedPhoneData> data =
+        readPlatformService.retrieveLinkedPhones(savingsAccountId);
+    return linkedPhoneSerializer.serializeResult(data);
   }
 
   private String getOptionalString(

--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/data/SinpeLinkedPhoneData.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/data/SinpeLinkedPhoneData.java
@@ -1,0 +1,18 @@
+package org.apache.fineract.fastpayment.sinpe.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SinpeLinkedPhoneData {
+
+  private Long savingsAccountId;
+  private String maskedIban;
+  private String mobileNumber;
+  private String status;
+}

--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/domain/SinpeEnrollmentRepository.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/domain/SinpeEnrollmentRepository.java
@@ -1,5 +1,6 @@
 package org.apache.fineract.fastpayment.sinpe.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -44,5 +45,15 @@ public interface SinpeEnrollmentRepository
    * @return matching enrollment, if present
    */
   Optional<SinpeEnrollment> findFirstBySavingsAccountIdAndStatus(
+      Long savingsAccountId, String status);
+
+  /**
+   * Finds active enrollment rows for a savings account and local link status.
+   *
+   * @param savingsAccountId savings account identifier
+   * @param status local link status
+   * @return matching enrollments
+   */
+  List<SinpeEnrollment> findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(
       Long savingsAccountId, String status);
 }

--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformService.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformService.java
@@ -1,7 +1,11 @@
 package org.apache.fineract.fastpayment.sinpe.service;
 
+import java.util.Collection;
+import org.apache.fineract.fastpayment.sinpe.data.SinpeLinkedPhoneData;
 import org.apache.fineract.fastpayment.sinpe.data.SinpePhoneStatusData;
 
 public interface SinpeEnrollmentReadPlatformService {
   SinpePhoneStatusData retrievePhoneStatus(String phoneNumber);
+
+  Collection<SinpeLinkedPhoneData> retrieveLinkedPhones(Long savingsAccountId);
 }

--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformServiceImpl.java
@@ -3,12 +3,17 @@ package org.apache.fineract.fastpayment.sinpe.service;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.fineract.fastpayment.sinpe.data.SinpeLinkedPhoneData;
 import org.apache.fineract.fastpayment.sinpe.data.SinpePhoneStatusData;
+import org.apache.fineract.fastpayment.sinpe.domain.SinpeEnrollment;
+import org.apache.fineract.fastpayment.sinpe.domain.SinpeEnrollmentRepository;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,8 +21,13 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class SinpeEnrollmentReadPlatformServiceImpl implements SinpeEnrollmentReadPlatformService {
 
+  private static final String LINKED = "LINKED";
+  private static final int IBAN_VISIBLE_SUFFIX_LENGTH = 4;
+
   private final PlatformSecurityContext context;
+  private final SinpeEnrollmentRepository enrollmentRepository;
   private final SavingsSinpeExternalApiClient sinpeExternalApiClient;
+  private final SavingsAccountReadPlatformService savingsAccountReadPlatformService;
   private final Gson gson = new Gson();
 
   @Override
@@ -67,6 +77,37 @@ public class SinpeEnrollmentReadPlatformServiceImpl implements SinpeEnrollmentRe
           .rawResponse(raw)
           .build();
     }
+  }
+
+  @Override
+  public Collection<SinpeLinkedPhoneData> retrieveLinkedPhones(final Long savingsAccountId) {
+    context.authenticatedUser().validateHasPermissionTo("READ_SINPE_ENROLLMENT");
+    context.authenticatedUser().validateHasReadPermission("savingsaccount");
+    savingsAccountReadPlatformService.retrieveOne(savingsAccountId);
+    return enrollmentRepository
+        .findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(savingsAccountId, LINKED).stream()
+        .map(this::toLinkedPhoneData)
+        .toList();
+  }
+
+  private SinpeLinkedPhoneData toLinkedPhoneData(final SinpeEnrollment enrollment) {
+    return SinpeLinkedPhoneData.builder()
+        .savingsAccountId(enrollment.getSavingsAccountId())
+        .maskedIban(maskIban(enrollment.getIban()))
+        .mobileNumber(enrollment.getMobileNumber())
+        .status(enrollment.getStatus())
+        .build();
+  }
+
+  private String maskIban(final String iban) {
+    if (StringUtils.isBlank(iban)) {
+      return null;
+    }
+    if (iban.length() <= IBAN_VISIBLE_SUFFIX_LENGTH) {
+      return "****";
+    }
+    String suffix = StringUtils.right(iban, IBAN_VISIBLE_SUFFIX_LENGTH);
+    return "****" + suffix;
   }
 
   private static String getAsString(JsonObject json, String member, String defaultValue) {

--- a/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentWritePlatformServiceImpl.java
+++ b/src/main/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentWritePlatformServiceImpl.java
@@ -228,7 +228,7 @@ public class SinpeEnrollmentWritePlatformServiceImpl
     // 2. Load client (multi-tenant aware)
     Client client = clientRepository.findOneWithNotFoundDetection(clientId);
     SavingsAccount savingsAccount = validateSavingsAccount(clientId, iban);
-    validateDuplicateLink(enrollment, phoneNumber, savingsAccount.getId());
+    validateDuplicateLink(enrollment, phoneNumber);
 
     // 3. Build the full external request from client data + defaults
     SinpeSubscriptionRequest request =
@@ -463,8 +463,7 @@ public class SinpeEnrollmentWritePlatformServiceImpl
 
   private void validateDuplicateLink(
       final SinpeEnrollment current,
-      final String phoneNumber,
-      final Long savingsAccountId) {
+      final String phoneNumber) {
     enrollmentRepository
         .findFirstByMobileNumberAndStatus(phoneNumber, LINKED)
         .filter(existing -> !isSameEnrollment(existing, current))
@@ -473,15 +472,6 @@ public class SinpeEnrollmentWritePlatformServiceImpl
               throw new GeneralPlatformDomainRuleException(
                   "error.msg.sinpe.identifier.already.linked",
                   "Phone number is already linked to a savings account.");
-            });
-    enrollmentRepository
-        .findFirstBySavingsAccountIdAndStatus(savingsAccountId, LINKED)
-        .filter(existing -> !isSameEnrollment(existing, current))
-        .ifPresent(
-            existing -> {
-              throw new GeneralPlatformDomainRuleException(
-                  "error.msg.sinpe.account.already.linked",
-                  "Savings account is already linked to a phone number.");
             });
   }
 

--- a/src/test/java/org/apache/fineract/fastpayment/sinpe/api/SinpeEnrollmentApiResourceTest.java
+++ b/src/test/java/org/apache/fineract/fastpayment/sinpe/api/SinpeEnrollmentApiResourceTest.java
@@ -1,0 +1,71 @@
+package org.apache.fineract.fastpayment.sinpe.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.fastpayment.sinpe.data.SinpeLinkedPhoneData;
+import org.apache.fineract.fastpayment.sinpe.data.SinpePhoneStatusData;
+import org.apache.fineract.fastpayment.sinpe.service.SinpeEnrollmentReadPlatformService;
+import org.apache.fineract.fastpayment.sinpe.service.SinpeEnrollmentWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SinpeEnrollmentApiResourceTest {
+
+  private static final Long SAVINGS_ACCOUNT_ID = 31L;
+
+  @Mock private PlatformSecurityContext context;
+  @Mock private SinpeEnrollmentWritePlatformService writePlatformService;
+  @Mock private SinpeEnrollmentReadPlatformService readPlatformService;
+  @Mock private DefaultToApiJsonSerializer<CommandProcessingResult> commandSerializer;
+  @Mock private DefaultToApiJsonSerializer<SinpePhoneStatusData> phoneStatusSerializer;
+  @Mock private DefaultToApiJsonSerializer<SinpeLinkedPhoneData> linkedPhoneSerializer;
+
+  private SinpeEnrollmentApiResource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource =
+        new SinpeEnrollmentApiResource(
+            context,
+            commandSerializer,
+            writePlatformService,
+            readPlatformService,
+            phoneStatusSerializer,
+            linkedPhoneSerializer);
+  }
+
+  @Test
+  void retrieveLinkedPhonesRequiresReadPermissionAndSerializesResult() {
+    AppUser user = mock(AppUser.class);
+    List<SinpeLinkedPhoneData> linkedPhones =
+        List.of(
+            SinpeLinkedPhoneData.builder()
+                .savingsAccountId(SAVINGS_ACCOUNT_ID)
+                .maskedIban("****4066")
+                .mobileNumber("88887777")
+                .status("LINKED")
+                .build());
+    when(context.authenticatedUser()).thenReturn(user);
+    when(readPlatformService.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID)).thenReturn(linkedPhones);
+    when(linkedPhoneSerializer.serializeResult(linkedPhones)).thenReturn("[]");
+
+    String result = resource.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+
+    assertEquals("[]", result);
+    verify(user).validateHasPermissionTo("READ_SINPE_ENROLLMENT");
+    verify(readPlatformService).retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+    verify(linkedPhoneSerializer).serializeResult(linkedPhones);
+  }
+}

--- a/src/test/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentReadPlatformServiceImplTest.java
@@ -1,0 +1,182 @@
+package org.apache.fineract.fastpayment.sinpe.service;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.apache.fineract.fastpayment.sinpe.data.SinpeLinkedPhoneData;
+import org.apache.fineract.fastpayment.sinpe.domain.SinpeEnrollment;
+import org.apache.fineract.fastpayment.sinpe.domain.SinpeEnrollmentRepository;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountReadPlatformService;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SinpeEnrollmentReadPlatformServiceImplTest {
+
+  private static final Long CLIENT_ID = 11L;
+  private static final Long SAVINGS_ACCOUNT_ID = 31L;
+  private static final Long USER_ID = 7L;
+  private static final String IBAN = "CR05015202001026284066";
+  private static final String MASKED_IBAN = "****4066";
+
+  @Mock private PlatformSecurityContext context;
+  @Mock private SinpeEnrollmentRepository enrollmentRepository;
+  @Mock private SavingsSinpeExternalApiClient sinpeExternalApiClient;
+  @Mock private SavingsAccountReadPlatformService savingsAccountReadPlatformService;
+  @Mock private AppUser user;
+
+  private SinpeEnrollmentReadPlatformServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new SinpeEnrollmentReadPlatformServiceImpl(
+            context,
+            enrollmentRepository,
+            sinpeExternalApiClient,
+            savingsAccountReadPlatformService);
+  }
+
+  @Test
+  void retrieveLinkedPhonesReturnsActiveLinksForSavingsAccount() {
+    when(context.authenticatedUser()).thenReturn(user);
+    when(enrollmentRepository.findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(
+            SAVINGS_ACCOUNT_ID, "LINKED"))
+        .thenReturn(
+            List.of(linkedEnrollment("88886666", IBAN), linkedEnrollment("88887777", IBAN)));
+
+    Collection<SinpeLinkedPhoneData> result = service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+
+    assertEquals(2, result.size());
+    List<SinpeLinkedPhoneData> linkedPhones = List.copyOf(result);
+    assertEquals(SAVINGS_ACCOUNT_ID, linkedPhones.get(0).getSavingsAccountId());
+    assertEquals(MASKED_IBAN, linkedPhones.get(0).getMaskedIban());
+    assertEquals("88886666", linkedPhones.get(0).getMobileNumber());
+    assertEquals("LINKED", linkedPhones.get(0).getStatus());
+    assertEquals("88887777", linkedPhones.get(1).getMobileNumber());
+    verify(user).validateHasPermissionTo("READ_SINPE_ENROLLMENT");
+    verify(user).validateHasReadPermission("savingsaccount");
+    verify(savingsAccountReadPlatformService).retrieveOne(SAVINGS_ACCOUNT_ID);
+  }
+
+  @Test
+  void retrieveLinkedPhonesDoesNotQueryLinksWithoutSavingsAccountReadAccess() {
+    RuntimeException accessDenied = new RuntimeException("access denied");
+    when(context.authenticatedUser()).thenReturn(user);
+    doThrow(accessDenied).when(user).validateHasReadPermission("savingsaccount");
+
+    RuntimeException result =
+        assertThrows(
+            RuntimeException.class, () -> service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID));
+
+    assertEquals(accessDenied, result);
+    verify(savingsAccountReadPlatformService, never()).retrieveOne(SAVINGS_ACCOUNT_ID);
+    verify(enrollmentRepository, never())
+        .findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(SAVINGS_ACCOUNT_ID, "LINKED");
+  }
+
+  @Test
+  void retrieveLinkedPhonesDoesNotQueryLinksWhenSavingsAccountCannotBeRead() {
+    RuntimeException notFound = new RuntimeException("not found");
+    when(context.authenticatedUser()).thenReturn(user);
+    when(savingsAccountReadPlatformService.retrieveOne(SAVINGS_ACCOUNT_ID)).thenThrow(notFound);
+
+    RuntimeException result =
+        assertThrows(
+            RuntimeException.class, () -> service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID));
+
+    assertEquals(notFound, result);
+    verify(enrollmentRepository, never())
+        .findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(SAVINGS_ACCOUNT_ID, "LINKED");
+  }
+
+  @Test
+  void retrieveLinkedPhonesReturnsEmptyWhenNoLinksExist() {
+    when(context.authenticatedUser()).thenReturn(user);
+    when(enrollmentRepository.findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(
+            SAVINGS_ACCOUNT_ID, "LINKED"))
+        .thenReturn(List.of());
+
+    Collection<SinpeLinkedPhoneData> result = service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void retrieveLinkedPhonesRequestsOnlyLinkedRows() {
+    when(context.authenticatedUser()).thenReturn(user);
+    List<SinpeEnrollment> enrollments =
+        List.of(
+            linkedEnrollment("88887777", IBAN),
+            unlinkedEnrollment("88886666", IBAN),
+            pendingEnrollment("88885555"));
+    when(enrollmentRepository.findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(
+            SAVINGS_ACCOUNT_ID, "LINKED"))
+        .thenAnswer(
+            invocation ->
+                enrollments.stream()
+                    .filter(enrollment -> invocation.getArgument(1).equals(enrollment.getStatus()))
+                    .toList());
+
+    Collection<SinpeLinkedPhoneData> result = service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+
+    assertEquals(1, result.size());
+    assertEquals("88887777", result.iterator().next().getMobileNumber());
+    verify(enrollmentRepository)
+        .findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(SAVINGS_ACCOUNT_ID, "LINKED");
+  }
+
+  @Test
+  void retrieveLinkedPhonesDoesNotExposeShortIbanValues() {
+    when(context.authenticatedUser()).thenReturn(user);
+    when(enrollmentRepository.findBySavingsAccountIdAndStatusOrderByMobileNumberAsc(
+            SAVINGS_ACCOUNT_ID, "LINKED"))
+        .thenReturn(List.of(linkedEnrollment("88887777", "1234")));
+
+    Collection<SinpeLinkedPhoneData> result = service.retrieveLinkedPhones(SAVINGS_ACCOUNT_ID);
+
+    assertEquals("****", result.iterator().next().getMaskedIban());
+  }
+
+  @Test
+  void linkedPhoneResponseDataExposesOnlySafeFields() {
+    Set<String> fields =
+        List.of(SinpeLinkedPhoneData.class.getDeclaredFields()).stream()
+            .map(Field::getName)
+            .collect(toSet());
+
+    assertEquals(Set.of("savingsAccountId", "maskedIban", "mobileNumber", "status"), fields);
+  }
+
+  private SinpeEnrollment linkedEnrollment(final String mobileNumber, final String iban) {
+    SinpeEnrollment enrollment = new SinpeEnrollment(CLIENT_ID, mobileNumber, USER_ID);
+    enrollment.markAsLinked(SAVINGS_ACCOUNT_ID, iban, LocalDateTime.now());
+    return enrollment;
+  }
+
+  private SinpeEnrollment unlinkedEnrollment(final String mobileNumber, final String iban) {
+    SinpeEnrollment enrollment = linkedEnrollment(mobileNumber, iban);
+    enrollment.markAsUnlinked(LocalDateTime.now());
+    return enrollment;
+  }
+
+  private SinpeEnrollment pendingEnrollment(final String mobileNumber) {
+    return new SinpeEnrollment(CLIENT_ID, mobileNumber, USER_ID);
+  }
+}

--- a/src/test/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentWritePlatformServiceImplTest.java
+++ b/src/test/java/org/apache/fineract/fastpayment/sinpe/service/SinpeEnrollmentWritePlatformServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -44,6 +45,7 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
   private static final Long USER_ID = 7L;
   private static final Long SAVINGS_ACCOUNT_ID = 31L;
   private static final String PHONE_NUMBER = "88887777";
+  private static final String OTHER_PHONE_NUMBER = "88886666";
   private static final String IBAN = "CR05015202001026284066";
   private static final String OTP = "123456";
   private static final String PREVIOUS_OTP = "OLDOTP";
@@ -80,7 +82,7 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
   }
 
   @Test
-  void requestEnrollmentCreatesPhoneOtpWithoutReturningOtp() {
+  void requestEnrollmentCreatesPhoneOtpAndReturnsIt() {
     when(clientRepository.findOneWithNotFoundDetection(CLIENT_ID)).thenReturn(client);
     when(enrollmentRepository.findByClientIdAndMobileNumberAndVerifiedTrue(CLIENT_ID, PHONE_NUMBER))
         .thenReturn(Optional.empty());
@@ -92,7 +94,7 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
 
     assertEquals(CLIENT_ID, result.getClientId());
     assertEquals(PHONE_NUMBER, result.getChanges().get("mobileNumber"));
-    assertFalse(result.getChanges().containsKey("otp"));
+    assertTrue(result.getChanges().containsKey("otp"));
     verify(clientRepository).findOneWithNotFoundDetection(CLIENT_ID);
     verify(enrollmentRepository).saveAndFlush(any(SinpeEnrollment.class));
   }
@@ -104,9 +106,8 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
         .thenReturn(Optional.of(enrollment));
     when(clientRepository.findOneWithNotFoundDetection(CLIENT_ID)).thenReturn(client);
     mockValidSavingsAccount(CLIENT_ID, IBAN);
+    when(savingsAccount.getId()).thenReturn(SAVINGS_ACCOUNT_ID);
     when(enrollmentRepository.findFirstByMobileNumberAndStatus(PHONE_NUMBER, "LINKED"))
-        .thenReturn(Optional.empty());
-    when(enrollmentRepository.findFirstBySavingsAccountIdAndStatus(SAVINGS_ACCOUNT_ID, "LINKED"))
         .thenReturn(Optional.empty());
     when(sinpeExternalApiClient.createSubscription(any())).thenReturn(PROVIDER_RESPONSE);
 
@@ -212,26 +213,34 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
   }
 
   @Test
-  void createSubscriptionRejectsDuplicateSavingsAccountLink() {
+  void createSubscriptionAllowsDifferentPhoneLinkedToSameSavingsAccount() {
     SinpeEnrollment enrollment = verifiedEnrollment();
-    SinpeEnrollment existing = verifiedEnrollment();
+    SinpeEnrollment existing = verifiedEnrollment(OTHER_PHONE_NUMBER, OTP);
     existing.markAsLinked(SAVINGS_ACCOUNT_ID, IBAN, LocalDateTime.now());
     when(enrollmentRepository.findByClientIdAndMobileNumber(CLIENT_ID, PHONE_NUMBER))
         .thenReturn(Optional.of(enrollment));
     when(clientRepository.findOneWithNotFoundDetection(CLIENT_ID)).thenReturn(client);
     mockValidSavingsAccount(CLIENT_ID, IBAN);
+    when(savingsAccount.getId()).thenReturn(SAVINGS_ACCOUNT_ID);
     when(enrollmentRepository.findFirstByMobileNumberAndStatus(PHONE_NUMBER, "LINKED"))
         .thenReturn(Optional.empty());
-    when(enrollmentRepository.findFirstBySavingsAccountIdAndStatus(SAVINGS_ACCOUNT_ID, "LINKED"))
+    lenient()
+        .when(
+            enrollmentRepository.findFirstBySavingsAccountIdAndStatus(
+                SAVINGS_ACCOUNT_ID, "LINKED"))
         .thenReturn(Optional.of(existing));
+    when(sinpeExternalApiClient.createSubscription(any())).thenReturn(PROVIDER_RESPONSE);
 
-    GeneralPlatformDomainRuleException exception =
-        assertThrows(
-            GeneralPlatformDomainRuleException.class,
-            () -> service.createSubscription(CLIENT_ID, PHONE_NUMBER, IBAN, OTP));
+    service.createSubscription(CLIENT_ID, PHONE_NUMBER, IBAN, OTP);
 
-    assertEquals("error.msg.sinpe.account.already.linked", exception.getGlobalisationMessageCode());
-    verify(sinpeExternalApiClient, never()).createSubscription(any());
+    assertTrue(enrollment.isLinked());
+    assertEquals(SAVINGS_ACCOUNT_ID, enrollment.getSavingsAccountId());
+    assertEquals(OTHER_PHONE_NUMBER, existing.getMobileNumber());
+    assertEquals(SAVINGS_ACCOUNT_ID, existing.getSavingsAccountId());
+    verify(sinpeExternalApiClient).createSubscription(any());
+    verify(enrollmentRepository).saveAndFlush(enrollment);
+    verify(enrollmentRepository, never())
+        .findFirstBySavingsAccountIdAndStatus(SAVINGS_ACCOUNT_ID, "LINKED");
   }
 
   @Test
@@ -262,8 +271,6 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
     when(clientRepository.findOneWithNotFoundDetection(CLIENT_ID)).thenReturn(client);
     mockValidSavingsAccount(CLIENT_ID, IBAN);
     when(enrollmentRepository.findFirstByMobileNumberAndStatus(PHONE_NUMBER, "LINKED"))
-        .thenReturn(Optional.empty());
-    when(enrollmentRepository.findFirstBySavingsAccountIdAndStatus(SAVINGS_ACCOUNT_ID, "LINKED"))
         .thenReturn(Optional.empty());
     when(sinpeExternalApiClient.createSubscription(any())).thenReturn(null);
 
@@ -431,7 +438,11 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
   }
 
   private SinpeEnrollment verifiedEnrollment(String otp) {
-    SinpeEnrollment enrollment = new SinpeEnrollment(CLIENT_ID, PHONE_NUMBER, USER_ID);
+    return verifiedEnrollment(PHONE_NUMBER, otp);
+  }
+
+  private SinpeEnrollment verifiedEnrollment(String mobileNumber, String otp) {
+    SinpeEnrollment enrollment = new SinpeEnrollment(CLIENT_ID, mobileNumber, USER_ID);
     enrollment.setPendingOtp(otp, LocalDateTime.now().plusMinutes(5));
     return enrollment;
   }
@@ -442,6 +453,5 @@ class SinpeEnrollmentWritePlatformServiceImplTest {
     when(savingsAccount.clientId()).thenReturn(ownerClientId);
     when(savingsAccount.isActive()).thenReturn(true);
     when(savingsAccount.getExternalId()).thenReturn(externalId);
-    when(savingsAccount.getId()).thenReturn(SAVINGS_ACCOUNT_ID);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secured API endpoint to retrieve active SINPE-linked phone numbers for a savings account.
  * Results include the savings account, IBAN, mobile number, and link status, ordered by mobile number.
  * Added validation for account existence and read permissions.

* **Bug Fixes**
  * Updated enrollment validation to allow multiple phone links for the same savings account while still preventing duplicate phone links.
  * Enrollment responses now expose the OTP where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->